### PR TITLE
fix: Resolve TypeScript errors from build output

### DIFF
--- a/credentials/ResendApi.credentials.ts
+++ b/credentials/ResendApi.credentials.ts
@@ -1,7 +1,7 @@
 import {
 	ICredentialType,
 	INodeProperties,
-	IAuthData,
+	IAuthenticateGeneric,
 } from 'n8n-workflow';
 
 export class ResendApi implements ICredentialType {
@@ -17,11 +17,12 @@ export class ResendApi implements ICredentialType {
 			required: true,
 		},
 	];
-	// Use IAuthData for authentication
-	authenticate: IAuthData = {
-		type: 'apiToken',
+	authenticate: IAuthenticateGeneric = {
+		type: 'generic',
 		properties: {
-			token: '={{$credentials.apiKey}}'
-		}
+			headers: {
+				Authorization: '={{"Bearer " + $credentials.apiKey}}',
+			},
+		},
 	};
 }

--- a/nodes/Resend/Resend.node.ts
+++ b/nodes/Resend/Resend.node.ts
@@ -4,6 +4,7 @@ import {
 	INodeType,
 	INodeTypeDescription,
 	NodeOperationError,
+	NodeConnectionType,
 } from 'n8n-workflow';
 
 export class Resend implements INodeType {
@@ -24,8 +25,8 @@ export class Resend implements INodeType {
 				required: true,
 			},
 		],
-		inputs: ['main'],
-		outputs: ['main'],
+		inputs: ['main' as NodeConnectionType],
+		outputs: ['main' as NodeConnectionType],
 		properties: [
 			{
 				displayName: 'Operation',
@@ -161,9 +162,6 @@ export class Resend implements INodeType {
 				displayName: 'Tags',
 				name: 'tags',
 				type: 'fixedCollection',
-				typeOptions: {
-					multipleValues: true,
-				},
 				default: {},
 				placeholder: 'Add Tag',
 				displayOptions: {
@@ -171,26 +169,31 @@ export class Resend implements INodeType {
 						operation: ['sendEmail'],
 					},
 				},
-				properties: [
-					{
-						name: 'tag',
-						displayName: 'Tag',
-						values: [
-							{
-								displayName: 'Name',
-								name: 'name',
-								type: 'string',
-								default: '',
-							},
-							{
-								displayName: 'Value',
-								name: 'value',
-								type: 'string',
-								default: '',
-							},
-						],
-					},
-				],
+				typeOptions: {
+					multipleValues: true,
+					properties: [
+						{
+							name: 'tag',
+							displayName: 'Tag',
+							values: [
+								{
+									displayName: 'Name',
+									name: 'name',
+									type: 'string',
+									default: '',
+									description: 'Name of the tag',
+								},
+								{
+									displayName: 'Value',
+									name: 'value',
+									type: 'string',
+									default: '',
+									description: 'Value of the tag',
+								},
+							],
+						},
+					],
+				},
 				description: 'Tags to categorize the email',
 			},
 		],


### PR DESCRIPTION
Addresses multiple TypeScript errors identified during the build process:

- Corrects `IAuthData` to `IAuthenticateGeneric` in `ResendApi.credentials.ts` and updates the authentication object structure.
- Fixes `inputs` and `outputs` type definitions in `Resend.node.ts` and `ResendTrigger.node.ts` by casting to `NodeConnectionType`.
- Corrects the structure of the `tags` fixedCollection property in `Resend.node.ts` by nesting its `properties` array within `typeOptions`.
- Restructures `webhookMethods` in `ResendTrigger.node.ts` for custom signature verification (`resendSignature`).
- Replaces incorrect method calls (`getRequestObject`, `getRequestBody`) with appropriate `IHookFunctions` methods (`getHeaderData`, `getRawBody`).
- Removes unused variables.
- Removes invalid `statusCode` options from `NodeApiError` constructors.

These changes ensure the codebase aligns with n8n's TypeScript interfaces and resolves the reported build errors.