### PR TITLE
feat: Add Human In The Loop (HITL) functionality to Resend node

### DIFF
--- a/nodes/Resend/Resend.node.test.ts
+++ b/nodes/Resend/Resend.node.test.ts
@@ -1,0 +1,130 @@
+import {
+	IExecuteFunctions,
+	INodeExecutionData,
+	NodeOperationError,
+	SEND_AND_WAIT_OPERATION,
+	IWebhookFunctions,
+	NodeConnectionType, // Added for Resend class type safety
+	WAIT_INDEFINITELY, // Added for Resend class type safety
+} from 'n8n-workflow';
+import { Resend } from './Resend.node';
+
+// Mock utilities that would be imported by Resend.node.ts
+// These paths are relative to Resend.node.ts.
+// If n8n uses Jest moduleNameMapper or another mechanism, this might need adjustment.
+jest.mock('../../packages/nodes-base/utils/sendAndWait/utils', () => ({
+	...jest.requireActual('../../packages/nodes-base/utils/sendAndWait/utils'), // Retain other exports
+	createButton: jest.fn((url, label, value, style) => `<a href='${url}?approved=${value}' style='${style}'>${label}</a>`),
+	getSendAndWaitConfig: jest.fn(params => params), // Simple mock, adjust if complex logic is needed
+}));
+
+jest.mock('../../packages/nodes-base/utils/sendAndWait/email-templates', () => ({
+	...jest.requireActual('../../packages/nodes-base/utils/sendAndWait/email-templates'),
+	createEmailBodyWithN8nAttribution: jest.fn((message, buttons, instanceId) => `<html><body>${message}${buttons}<!-- ${instanceId} --></body></html>`),
+	createEmailBodyWithoutN8nAttribution: jest.fn((message, buttons) => `<html><body>${message}${buttons}</body></html>`),
+	ACTION_RECORDED_PAGE: '<html><body>Action Recorded</body></html>',
+}));
+
+jest.mock('../../packages/nodes-base/utils/sendAndWait/configureWaitTillDate.util', () => ({
+	configureWaitTillDate: jest.fn(() => new Date()), // Simple mock
+}));
+
+
+describe('Resend Node - HITL Functionality', () => {
+	let executeFunctions: IExecuteFunctions;
+
+	beforeEach(() => {
+		executeFunctions = {
+			getCredentials: jest.fn().mockResolvedValue({ apiKey: 'test-api-key' }),
+			getNodeParameter: jest.fn(),
+			getInputData: jest.fn().mockReturnValue([{ json: {}, pairedItem: { item: 0 } }]), // Default input
+			evaluateExpression: jest.fn(expr => {
+				if (expr === '{{ $execution?.resumeUrl }}') return 'https://n8n.example.com/resume';
+				if (expr === '{{ $nodeId }}') return 'test-node-id';
+				return expr; // Fallback for other expressions if any
+			}),
+			getInstanceId: jest.fn().mockReturnValue('test-instance-id'),
+			putExecutionToWait: jest.fn().mockResolvedValue(undefined), // For send test, resolve immediately
+			helpers: {
+				httpRequest: jest.fn().mockResolvedValue({ id: 'email-send-receipt-xyz' }), // Mock Resend API success
+			},
+			continueOnFail: jest.fn().mockReturnValue(false),
+			// Mock getNode and its getNodeParameter for potential internal calls if any
+			getNode: jest.fn().mockReturnValue({ 
+				getNodeParameter: jest.fn(),
+				getContext: jest.fn().mockReturnValue({}), // Add if context is used
+			} as any),
+		} as unknown as IExecuteFunctions;
+	});
+
+	test('should construct and send HITL email correctly for approval type (single button)', async () => {
+		(executeFunctions.getNodeParameter as jest.Mock)
+			.mockImplementation((paramName: string, itemIndex: number, defaultValue?: any) => {
+				// console.log(`getNodeParameter called for: ${paramName}`); // For debugging
+				if (paramName === 'resource') return 'email';
+				if (paramName === 'operation') return SEND_AND_WAIT_OPERATION;
+				if (paramName === 'fromHitl') return 'sender@example.com';
+				if (paramName === 'toHitl') return 'receiver@example.com';
+				if (paramName === 'subjectHitl') return 'Test Subject HITL - Approval Single';
+				if (paramName === 'messageHitl') return 'Test Message for Approval';
+				if (paramName === 'responseTypeHitl') return 'approval';
+				if (paramName === 'approvalOptionsHitl.values') {
+					return { 
+						approvalType: 'single', 
+						approveLabel: 'Approve Now!',
+						buttonApprovalStyle: 'primary',
+					};
+				}
+				if (paramName === 'hitlSettings') {
+					return { 
+						appendAttribution: true, 
+						limitWaitTime: { values: { limitType: 'afterTimeInterval', resumeAmount: 30, resumeUnit: 'minutes' } } 
+					};
+				}
+				return defaultValue;
+			});
+
+		const node = new Resend();
+		// Call execute method with the mocked 'this' context
+		await node.execute.call(executeFunctions as IExecuteFunctions);
+
+		expect(executeFunctions.helpers.httpRequest).toHaveBeenCalledTimes(1);
+		expect(executeFunctions.helpers.httpRequest).toHaveBeenCalledWith(
+			expect.objectContaining({
+				method: 'POST',
+				url: 'https://api.resend.com/emails',
+				body: expect.objectContaining({
+					from: 'sender@example.com',
+					to: ['receiver@example.com'],
+					subject: 'Test Subject HITL - Approval Single',
+					html: expect.stringContaining("<html><body>Test Message for Approval<a href='https://n8n.example.com/resume/test-node-id?approved=true' style='primary'>Approve Now!</a><!-- test-instance-id --></body></html>"),
+				}),
+				headers: expect.objectContaining({
+					Authorization: 'Bearer test-api-key',
+					'Content-Type': 'application/json',
+				}),
+				json: true, // As per Resend.node.ts
+			}),
+		);
+		// Check if putExecutionToWait was called. The exact date can be tricky, so expect.anything() or a more specific check if needed.
+		expect(executeFunctions.putExecutionToWait).toHaveBeenCalledWith(expect.any(Date)); 
+	});
+	
+	// Placeholder for more tests as suggested in the prompt
+	test.todo('should construct and send HITL email correctly for approval type (double button)');
+	test.todo('should construct and send HITL email correctly for free text type');
+	test.todo('webhook should handle approval response correctly');
+	test.todo('webhook should render free text form on GET and handle POST response');
+	test.todo('execute should return original data on HITL timeout');
+	test.todo('execute should return webhook data if received for HITL');
+
+});
+
+// Minimal IWebhookFunctions mock for completeness if webhook tests are added later
+const mockWebhookFunctions = {
+    getRequestObject: jest.fn(),
+    getResponseObject: jest.fn().mockReturnValue({ render: jest.fn(), status: jest.fn().mockReturnThis(), send: jest.fn() }),
+    getNodeParameter: jest.fn(),
+    getBodyData: jest.fn(),
+    // ... other IWebhookFunctions methods if needed
+} as unknown as IWebhookFunctions;

--- a/nodes/Resend/Resend.node.ts
+++ b/nodes/Resend/Resend.node.ts
@@ -5,7 +5,21 @@ import {
 	INodeTypeDescription,
 	NodeOperationError,
 	NodeConnectionType,
+	SEND_AND_WAIT_OPERATION,
+	WAIT_INDEFINITELY, // Ensure this is imported
+	IWebhookFunctions, // Added for webhook
+	// IDataObject, // If needed for body data, can be added later
 } from 'n8n-workflow';
+
+// Imports for HITL functionality
+import { getSendAndWaitConfig, createButton } from '../../packages/nodes-base/utils/sendAndWait/utils';
+import { createEmailBodyWithN8nAttribution, createEmailBodyWithoutN8nAttribution } from '../../packages/nodes-base/utils/sendAndWait/email-templates';
+import { configureWaitTillDate } from '../../packages/nodes-base/utils/sendAndWait/configureWaitTillDate.util';
+import type { SendAndWaitConfig } from '../../packages/nodes-base/utils/sendAndWait/utils'; // For type usage
+
+// Imports for Webhook functionality
+import { ACTION_RECORDED_PAGE } from '../../packages/nodes-base/utils/sendAndWait/email-templates';
+// import { prepareFormData } from '../../packages/nodes-base/utils/sendAndWait/utils'; // prepareFormData might be too complex, direct construction used
 
 export class Resend implements INodeType {
 	description: INodeTypeDescription = {
@@ -103,6 +117,12 @@ export class Resend implements INodeType {
 						action: 'Send batch emails',
 					},
 					{
+						name: 'Send and Wait for Response',
+						value: 'sendAndWait',
+						description: 'Send an email and wait for a user response via a webhook',
+						action: 'Send an email and wait for response',
+					},
+					{
 						name: 'Update',
 						value: 'update',
 						description: 'Update an email',
@@ -130,12 +150,12 @@ export class Resend implements INodeType {
 				displayOptions: {
 					show: {
 						resource: ['email'],
-						operation: ['send', 'sendBatch'],
+						operation: ['send', 'sendBatch'], // sendAndWait will have its own email format property
 					},
 				},
 				description: 'Choose the format for your email content. HTML allows rich formatting, text is simple and universally compatible.',
 			},
-			// Properties for "Send Email" operation
+			// Properties for "Send Email" operation (operation: send)
 			{
 				displayName: 'From',
 				name: 'from',
@@ -180,7 +200,8 @@ export class Resend implements INodeType {
 					},
 				},
 				description: 'Email subject line',
-			}, {
+			},
+			{
 				displayName: 'HTML Content',
 				name: 'html',
 				type: 'string',
@@ -229,7 +250,8 @@ export class Resend implements INodeType {
 						resource: ['email'],
 						operation: ['send'],
 					},
-				},				options: [
+				},
+				options: [
 					{
 						displayName: 'Attachments',
 						name: 'attachments',
@@ -346,7 +368,8 @@ export class Resend implements INodeType {
 						operation: ['sendBatch'],
 					},
 				},
-				description: 'Array of emails to send (max 100). Note: Attachments are not supported with batch emails.', options: [{
+				description: 'Array of emails to send (max 100). Note: Attachments are not supported with batch emails.',
+				options: [{
 					name: 'emails',
 					displayName: 'Email',
 					values: [
@@ -411,6 +434,280 @@ export class Resend implements INodeType {
 						},
 					],
 				},
+				],
+			},
+
+			// Properties for "Send and Wait for Response" Email Operation (value: sendAndWait)
+			{
+				displayName: 'From (HITL)',
+				name: 'fromHitl',
+				type: 'string',
+				required: true,
+				default: '',
+				placeholder: 'you@example.com',
+				displayOptions: {
+					show: {
+						resource: ['email'],
+						operation: ['sendAndWait'],
+					},
+				},
+				description: 'Sender email address for HITL. Format: "Your Name <sender@domain.com>".',
+			},
+			{
+				displayName: 'To (HITL)',
+				name: 'toHitl',
+				type: 'string',
+				required: true,
+				default: '',
+				placeholder: 'user@example.com',
+				displayOptions: {
+					show: {
+						resource: ['email'],
+						operation: ['sendAndWait'],
+					},
+				},
+				description: 'Recipient email address for HITL.',
+			},
+			{
+				displayName: 'Subject (HITL)',
+				name: 'subjectHitl',
+				type: 'string',
+				required: true,
+				default: '',
+				placeholder: 'Approval Required: Action Needed',
+				displayOptions: {
+					show: {
+						resource: ['email'],
+						operation: ['sendAndWait'],
+					},
+				},
+				description: 'Email subject line for HITL.',
+			},
+			{
+				displayName: 'Message (HITL)',
+				name: 'messageHitl',
+				type: 'string',
+				required: true,
+				default: '',
+				typeOptions: {
+					rows: 4,
+					multiline: true,
+				},
+				placeholder: 'Please review the following request...',
+				displayOptions: {
+					show: {
+						resource: ['email'],
+						operation: ['sendAndWait'],
+					},
+				},
+				description: 'The main message content of the email asking for a response.',
+			},
+			{
+				displayName: 'Response Type (HITL)',
+				name: 'responseTypeHitl',
+				type: 'options',
+				default: 'approval',
+				displayOptions: {
+					show: {
+						resource: ['email'],
+						operation: ['sendAndWait'],
+					},
+				},
+				options: [
+					{
+						name: 'Approval',
+						value: 'approval',
+						description: 'User can approve/disapprove from within the message',
+					},
+					{
+						name: 'Free Text',
+						value: 'freeText',
+						description: 'User can submit a response via a form',
+					},
+				],
+				description: 'The type of response expected from the user for HITL.',
+			},
+			// --- Approval Options for HITL ---
+			{
+				displayName: 'Approval Options (HITL)',
+				name: 'approvalOptionsHitl',
+				type: 'fixedCollection',
+				placeholder: 'Add approval option',
+				default: {},
+				displayOptions: {
+					show: {
+						resource: ['email'],
+						operation: ['sendAndWait'],
+						responseTypeHitl: ['approval'],
+					},
+				},
+				options: [
+					{
+						displayName: 'Values',
+						name: 'values',
+						values: [
+							{
+								displayName: 'Type of Approval',
+								name: 'approvalType',
+								type: 'options',
+								default: 'single',
+								options: [
+									{ name: 'Approve Only', value: 'single' },
+									{ name: 'Approve and Disapprove', value: 'double' },
+								],
+							},
+							{
+								displayName: 'Approve Button Label',
+								name: 'approveLabel',
+								type: 'string',
+								default: 'Approve',
+							},
+							{
+								displayName: 'Approve Button Style',
+								name: 'buttonApprovalStyle',
+								type: 'options',
+								default: 'primary',
+								options: [
+									{ name: 'Primary', value: 'primary' },
+									{ name: 'Secondary', value: 'secondary' },
+								],
+							},
+							{
+								displayName: 'Disapprove Button Label',
+								name: 'disapproveLabel',
+								type: 'string',
+								default: 'Decline',
+								displayOptions: { show: { approvalType: ['double'] } },
+							},
+							{
+								displayName: 'Disapprove Button Style',
+								name: 'buttonDisapprovalStyle',
+								type: 'options',
+								default: 'secondary',
+								options: [
+									{ name: 'Primary', value: 'primary' },
+									{ name: 'Secondary', value: 'secondary' },
+								],
+								displayOptions: { show: { approvalType: ['double'] } },
+							},
+						],
+					},
+				],
+			},
+			// --- Options for Free Text HITL ---
+			{
+				displayName: 'Free Text Options (HITL)',
+				name: 'freeTextOptionsHitl',
+				type: 'collection',
+				placeholder: 'Add option',
+				default: {},
+				displayOptions: {
+					show: {
+						resource: ['email'],
+						operation: ['sendAndWait'],
+						responseTypeHitl: ['freeText'],
+					},
+				},
+				options: [
+					{
+						displayName: 'Message Button Label',
+						name: 'messageButtonLabel',
+						type: 'string',
+						default: 'Respond',
+					},
+					{
+						displayName: 'Response Form Title',
+						name: 'responseFormTitle',
+						type: 'string',
+						default: 'Provide Your Response',
+					},
+					{
+						displayName: 'Response Form Description',
+						name: 'responseFormDescription',
+						type: 'string',
+						default: '',
+					},
+					{
+						displayName: 'Response Form Button Label',
+						name: 'responseFormButtonLabel',
+						type: 'string',
+						default: 'Submit',
+					},
+				],
+			},
+			// --- General HITL Settings ---
+			{
+				displayName: 'HITL Settings',
+				name: 'hitlSettings',
+				type: 'collection',
+				placeholder: 'Add setting',
+				default: {},
+				displayOptions: {
+					show: {
+						resource: ['email'],
+						operation: ['sendAndWait'],
+					},
+				},
+				options: [
+					{
+						displayName: 'Limit Wait Time',
+						name: 'limitWaitTime',
+						type: 'fixedCollection',
+						description: 'Whether the workflow will automatically resume execution after the specified limit type',
+						default: { values: { limitType: 'afterTimeInterval', resumeAmount: 45, resumeUnit: 'minutes' } },
+						options: [
+							{
+								displayName: 'Values',
+								name: 'values',
+								values: [
+									{
+										displayName: 'Limit Type',
+										name: 'limitType',
+										type: 'options',
+										default: 'afterTimeInterval',
+										options: [
+											{ name: 'After Time Interval', value: 'afterTimeInterval' },
+											{ name: 'Until Specific Date/Time', value: 'specificDateTime' },
+										],
+									},
+									{
+										displayName: 'Resume After',
+										name: 'resumeAmount',
+										type: 'number',
+										default: 45,
+										typeOptions: { minValue: 1 },
+										displayOptions: { show: { limitType: ['afterTimeInterval'] } },
+									},
+									{
+										displayName: 'Unit',
+										name: 'resumeUnit',
+										type: 'options',
+										default: 'minutes',
+										options: [
+											{ name: 'Minutes', value: 'minutes' },
+											{ name: 'Hours', value: 'hours' },
+											{ name: 'Days', value: 'days' },
+										],
+										displayOptions: { show: { limitType: ['afterTimeInterval'] } },
+									},
+									{
+										displayName: 'Date & Time',
+										name: 'maxDateAndTime',
+										type: 'dateTime',
+										default: '',
+										displayOptions: { show: { limitType: ['specificDateTime'] } },
+									},
+								],
+							},
+						],
+					},
+					{
+						displayName: 'Append n8n Attribution',
+						name: 'appendAttribution',
+						type: 'boolean',
+						default: true,
+						description: 'Whether to include n8n branding in the email.',
+					},
 				],
 			},
 
@@ -1150,7 +1447,136 @@ export class Resend implements INodeType {
 
 				// EMAIL OPERATIONS
 				if (resource === 'email') {
-					if (operation === 'send') {
+					if (operation === SEND_AND_WAIT_OPERATION) {
+						const fromHitl = this.getNodeParameter('fromHitl', i) as string;
+						const toHitl = this.getNodeParameter('toHitl', i) as string;
+						const subjectHitl = this.getNodeParameter('subjectHitl', i) as string;
+						const messageHitl = this.getNodeParameter('messageHitl', i) as string;
+
+						const responseTypeHitl = this.getNodeParameter('responseTypeHitl', i, 'approval') as string;
+						// For fixedCollection, .values is conventional to get the inner object
+						const approvalOptionsActualValues = this.getNodeParameter('approvalOptionsHitl.values', i, {}) as any;
+						// For collection, parameters are usually direct children
+						const freeTextOptionsActualValues = this.getNodeParameter('freeTextOptionsHitl', i, {}) as any;
+						const hitlSettingsActualValues = this.getNodeParameter('hitlSettings', i, {}) as any;
+
+						const resumeUrl = this.evaluateExpression('{{ $execution?.resumeUrl }}', i) as string;
+						const nodeId = this.evaluateExpression('{{ $nodeId }}', i) as string;
+						const fullWebhookUrl = `${resumeUrl}/${nodeId}`;
+
+						const config: SendAndWaitConfig = {
+							title: subjectHitl,
+							message: messageHitl,
+							url: fullWebhookUrl,
+							options: [],
+							appendAttribution: hitlSettingsActualValues.appendAttribution !== false,
+						};
+
+						if (responseTypeHitl === 'approval') {
+							if (approvalOptionsActualValues.approvalType === 'double') {
+								config.options.push({
+									label: approvalOptionsActualValues.disapproveLabel || 'Decline',
+									value: 'false',
+									style: approvalOptionsActualValues.buttonDisapprovalStyle || 'secondary',
+								});
+								config.options.push({
+									label: approvalOptionsActualValues.approveLabel || 'Approve',
+									value: 'true',
+									style: approvalOptionsActualValues.buttonApprovalStyle || 'primary',
+								});
+							} else { // single approval
+								config.options.push({
+									label: approvalOptionsActualValues.approveLabel || 'Approve',
+									value: 'true',
+									style: approvalOptionsActualValues.buttonApprovalStyle || 'primary',
+								});
+							}
+						} else if (responseTypeHitl === 'freeText') {
+							config.options.push({
+								label: freeTextOptionsActualValues.messageButtonLabel || 'Respond',
+								value: 'true', // Value for freeText can be generic 'true'
+								style: 'primary',
+							});
+						}
+
+						const buttons: string[] = [];
+						for (const option of config.options) {
+							buttons.push(createButton(config.url, option.label, option.value, option.style));
+						}
+
+						let htmlBody: string;
+						const instanceId = this.getInstanceId?.() ?? '';
+						if (config.appendAttribution) {
+							htmlBody = createEmailBodyWithN8nAttribution(config.message, buttons.join('\n'), instanceId);
+						} else {
+							htmlBody = createEmailBodyWithoutN8nAttribution(config.message, buttons.join('\n'));
+						}
+
+						const requestBody: any = {
+							from: fromHitl,
+							to: toHitl.split(',').map((email: string) => email.trim()).filter((email: string) => email),
+							subject: config.title,
+							html: htmlBody,
+						};
+
+						// Ensure 'response' is declared in the loop's scope, e.g., let response: any;
+						response = await this.helpers.httpRequest({
+							url: 'https://api.resend.com/emails',
+							method: 'POST',
+							headers: {
+								Authorization: `Bearer ${apiKey}`, // apiKey from the loop's scope
+								'Content-Type': 'application/json',
+							},
+							body: requestBody,
+							json: true,
+						});
+
+						let waitTill = WAIT_INDEFINITELY;
+						const limitWaitTimeCollection = hitlSettingsActualValues.limitWaitTime as any;
+						// Check if limitWaitTimeCollection and its 'values' property exist
+						const limitWaitTimeValues = limitWaitTimeCollection?.values;
+
+						if (limitWaitTimeValues && Object.keys(limitWaitTimeValues).length > 0) {
+							try {
+								if (limitWaitTimeValues.limitType === 'afterTimeInterval') {
+									let waitAmount = (limitWaitTimeValues.resumeAmount as number) || 45;
+									const resumeUnit = (limitWaitTimeValues.resumeUnit as string) || 'minutes';
+									if (resumeUnit === 'minutes') waitAmount *= 60;
+									else if (resumeUnit === 'hours') waitAmount *= 60 * 60;
+									else if (resumeUnit === 'days') waitAmount *= 60 * 60 * 24;
+									waitAmount *= 1000;
+									waitTill = new Date(new Date().getTime() + waitAmount);
+								} else if (limitWaitTimeValues.limitType === 'specificDateTime') {
+									waitTill = new Date(limitWaitTimeValues.maxDateAndTime as string);
+								}
+								if (isNaN(waitTill.getTime())) {
+									throw new NodeOperationError(this.getNode(), 'Invalid date format for HITL wait time limit.', { itemIndex: i });
+								}
+							} catch (error: any) {
+								throw new NodeOperationError(this.getNode(), `Could not configure HITL Limit Wait Time: ${error.message}`, {
+									itemIndex: i,
+									description: error.message,
+								});
+							}
+						}
+
+						const webhookResponseData = await this.putExecutionToWait(waitTill);
+
+						if (webhookResponseData && webhookResponseData.length > 0) {
+							// Assuming webhookResponseData is INodeExecutionData[] for the current item.
+							// Each piece of INodeExecutionData should be paired with the input item index 'i'.
+							const finalOutputItems = webhookResponseData.map(data => ({ 
+								json: data.json, 
+								binary: data.binary, 
+								pairedItem: { item: i } 
+							}));
+							returnData.push(...finalOutputItems);
+						} else {
+							// Handle timeout or empty response: n8n convention is often to return original input data.
+							returnData.push(items[i]); 
+						}
+						continue; // Important: skip default response handling for this item
+					} else if (operation === 'send') {
 						const from = this.getNodeParameter('from', i) as string;
 						const to = this.getNodeParameter('to', i) as string;
 						const subject = this.getNodeParameter('subject', i) as string;
@@ -1677,9 +2103,17 @@ export class Resend implements INodeType {
 							json: true,
 						});
 					}
+					// Note: The 'continue;' statement for SEND_AND_WAIT_OPERATION 
+					// prevents the code below from executing for that operation.
 				}
 
-				returnData.push({ json: response, pairedItem: { item: i } });
+
+				// For operations other than SEND_AND_WAIT_OPERATION, or if resource is not 'email',
+				// this will push the API response.
+				// If operation was SEND_AND_WAIT_OPERATION, 'continue' would have skipped this.
+				if (operation !== SEND_AND_WAIT_OPERATION || resource !== 'email') {
+					returnData.push({ json: response, pairedItem: { item: i } });
+				}
 			} catch (error) {
 				if (this.continueOnFail()) {
 					returnData.push({ json: { error: error.message }, pairedItem: { item: i } });
@@ -1690,4 +2124,74 @@ export class Resend implements INodeType {
 		}
 		return [returnData];
 	}
+
+	// ======== WEBHOOK METHOD START ==========
+	async webhook(this: IWebhookFunctions): Promise<any> {
+		const req = this.getRequestObject();
+		const res = this.getResponseObject();
+
+		// Get the responseTypeHitl from the node's saved parameters
+		// Note: In a webhook, we don't have itemIndex, so we use 0 or assume it's consistent for the node.
+		const responseTypeHitl = this.getNodeParameter('responseTypeHitl', 0, 'approval') as string;
+
+		if (responseTypeHitl === 'approval') {
+			const query = req.query as { approved?: 'true' | 'false' | string };
+			const approved = query.approved === 'true';
+
+			return {
+				webhookResponse: ACTION_RECORDED_PAGE,
+				workflowData: [[{ json: { data: { approved } } }]],
+			};
+		} else if (responseTypeHitl === 'freeText') {
+			const freeTextOptions = this.getNodeParameter('freeTextOptionsHitl', 0, {}) as any;
+
+			if (req.method === 'GET') {
+				const formTitle = freeTextOptions.responseFormTitle || 'Provide Your Response';
+				// Using messageHitl as the primary source for form description as per instruction, fallback if needed
+				let formDescription = this.getNodeParameter('messageHitl', 0, '') as string;
+				if (!formDescription && freeTextOptions.responseFormDescription) {
+					formDescription = freeTextOptions.responseFormDescription;
+				}
+				const buttonLabel = freeTextOptions.responseFormButtonLabel || 'Submit';
+
+				// Simplified form data preparation for a single textarea
+				const data = {
+					formTitle: formTitle,
+					formDescription: formDescription.replace(/\n/g, '<br>'), // Ensure newlines are rendered as <br> in HTML
+					formSubmittedHeader: 'Got it, thanks',
+					formSubmittedText: 'This page can be closed now',
+					buttonLabel: buttonLabel,
+					formFields: [
+						{
+							fieldLabel: 'Response',
+							fieldType: 'textarea',
+							fieldName: 'responseText', // fieldName for the textarea
+							requiredField: true,
+						},
+					],
+					// Additional fields that might be expected by 'form-trigger' template
+					httpMethod: 'POST', // Usually form submission method
+					webhookUrl: req.url,   // The URL the form should post to
+				};
+
+				// The 'form-trigger' template is part of n8n's core views.
+				res.render('form-trigger', data);
+				return { noWebhookResponse: true };
+
+			} else if (req.method === 'POST') {
+				const bodyData = this.getBodyData() as { responseText?: string }; // Assuming fieldName is 'responseText'
+				const textResponse = bodyData.responseText || '';
+
+				return {
+					webhookResponse: ACTION_RECORDED_PAGE,
+					workflowData: [[{ json: { data: { text: textResponse } } }]],
+				};
+			}
+		}
+
+		// Fallback or error for unhandled response types or methods
+		res.status(404).send('Webhook response type not configured or method not supported.');
+		return { noWebhookResponse: true };
+	}
+	// ======== WEBHOOK METHOD END ==========
 }


### PR DESCRIPTION
This commit introduces a "Send and Wait for Response" operation to the Resend node, enabling Human In The Loop workflows.

Key features:
- New 'sendAndWait' operation for the 'email' resource.
- Dedicated UI properties for configuring the HITL email, including:
    - Sender (From), Recipient (To), Subject, Message.
    - Response Type: 'Approval' (with customizable button labels/styles) and 'Free Text' (rendering a form for your input).
    - Wait time limits (duration or specific date/time).
    - Option to append n8n attribution.
- The `execute` method now:
    - Constructs the HITL email with response buttons/links using n8n's core `sendAndWait` utilities.
    - Sends the email through the Resend API.
    - Pauses workflow execution via `putExecutionToWait`.
    - Outputs data received from the webhook (or original input on timeout).
- A new `webhook` method handles:
    - Processing approval link clicks (true/false).
    - Rendering a form for 'Free Text' responses on GET.
    - Processing 'Free Text' form submissions on POST.
    - Returning captured data to the workflow.
- Display logic for node properties has been updated to show relevant fields based on the selected operation ('send' vs. 'sendAndWait').
- Initial unit tests (`Resend.node.test.ts`) have been added, including mocks and a test case for the HITL email sending flow.

This functionality mirrors the HITL capabilities of core n8n nodes like EmailSend, allowing you to build interactive workflows that require human intervention via email.