### PR TITLE
docs: add comprehensive API coverage table to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,28 @@
 
 A community node for [n8n](https://n8n.io) that integrates with the [Resend](https://resend.com) email API. Send emails, manage contacts, handle domains, and receive webhooks.
 
+## API Coverage
+
+Comprehensive coverage of the Resend API (v1.1.0). The table below shows which endpoints are currently implemented:
+
+| API Resource                 | Endpoint                                   | Status          | Operations                                                      |
+| ---------------------------- | ------------------------------------------ | --------------- | --------------------------------------------------------------- |
+| **Email**              | `/emails`                                | ✅ Full         | Send, Send Batch, List, Get, Update, Cancel                     |
+| **Email Attachments**  | `/emails/{id}/attachments`               | ❌ Missing      | List attachments, Get attachment                                |
+| **Receiving Emails**   | `/emails/receiving`                      | ❌ Missing      | List received, Get received, Get attachments                    |
+| **Domains**            | `/domains`                               | ✅ Full         | Create, List, Get, Update, Delete, Verify                       |
+| **API Keys**           | `/api-keys`                              | ✅ Full         | Create, List, Delete                                            |
+| **Templates**          | `/templates`                             | ⚠️ Partial    | Create, List, Get, Update, Delete (Missing: Publish, Duplicate) |
+| **Audiences**          | `/audiences`                             | ⚠️ Deprecated | Replaced by Segments in v2.0.0                                  |
+| **Contacts**           | `/audiences/{id}/contacts`               | ✅ Full         | Create, List, Get, Update, Delete                               |
+| **Contact Segments**   | `/audiences/{id}/contacts/{id}/segments` | ❌ Missing      | Add to segment, List segments, Remove from segment              |
+| **Contact Topics**     | `/audiences/{id}/contacts/{id}/topics`   | ❌ Missing      | Get topics, Update topics                                       |
+| **Broadcasts**         | `/broadcasts`                            | ✅ Full         | Create, List, Get, Update, Delete, Send                         |
+| **Segments**           | `/segments`                              | ⚠️ Partial    | Create, List, Get, Delete (Missing: Update, Filter conditions)  |
+| **Topics**             | `/topics`                                | ✅ Full         | Create, List, Get, Update, Delete                               |
+| **Contact Properties** | `/contact-properties`                    | ✅ Full         | Create, List, Get, Update, Delete                               |
+| **Webhooks**           | `/webhooks`                              | ✅ Full         | Create, List, Get, Update, Delete                               |
+
 ## Installation
 
 ### Community Nodes (Recommended)
@@ -56,123 +78,123 @@ docker run -it --rm \
 
 ### Email
 
-| Operation | Description |
-|-----------|-------------|
-| Send | Send a single email with optional attachments |
-| Send Batch | Send up to 100 emails in one request |
-| List | List sent emails |
-| Get | Retrieve email details and status |
-| Cancel | Cancel a scheduled email |
-| Update | Modify a scheduled email |
+| Operation  | Description                                   |
+| ---------- | --------------------------------------------- |
+| Send       | Send a single email with optional attachments |
+| Send Batch | Send up to 100 emails in one request          |
+| List       | List sent emails                              |
+| Get        | Retrieve email details and status             |
+| Cancel     | Cancel a scheduled email                      |
+| Update     | Modify a scheduled email                      |
 
 ### Contact
 
-| Operation | Description |
-|-----------|-------------|
-| Create | Add a new contact |
-| Get | Retrieve contact details |
-| Update | Modify contact information |
-| Delete | Remove a contact |
-| List | List all contacts |
+| Operation | Description                |
+| --------- | -------------------------- |
+| Create    | Add a new contact          |
+| Get       | Retrieve contact details   |
+| Update    | Modify contact information |
+| Delete    | Remove a contact           |
+| List      | List all contacts          |
 
 ### Contact Property
 
-| Operation | Description |
-|-----------|-------------|
-| Create | Create a custom contact property |
-| Get | Retrieve property details |
-| Update | Modify property settings |
-| Delete | Remove a property |
-| List | List all contact properties |
+| Operation | Description                      |
+| --------- | -------------------------------- |
+| Create    | Create a custom contact property |
+| Get       | Retrieve property details        |
+| Update    | Modify property settings         |
+| Delete    | Remove a property                |
+| List      | List all contact properties      |
 
 ### Segment
 
-| Operation | Description |
-|-----------|-------------|
-| Create | Create a new segment |
-| Get | Retrieve segment details |
-| Delete | Remove a segment |
-| List | List all segments |
+| Operation | Description              |
+| --------- | ------------------------ |
+| Create    | Create a new segment     |
+| Get       | Retrieve segment details |
+| Delete    | Remove a segment         |
+| List      | List all segments        |
 
 ### Topic
 
-| Operation | Description |
-|-----------|-------------|
-| Create | Create a subscription topic |
-| Get | Retrieve topic details |
-| Update | Modify topic settings |
-| Delete | Remove a topic |
-| List | List all topics |
+| Operation | Description                 |
+| --------- | --------------------------- |
+| Create    | Create a subscription topic |
+| Get       | Retrieve topic details      |
+| Update    | Modify topic settings       |
+| Delete    | Remove a topic              |
+| List      | List all topics             |
 
 ### Broadcast
 
-| Operation | Description |
-|-----------|-------------|
-| Create | Create an email campaign |
-| Get | Retrieve broadcast details |
-| Send | Send a broadcast to a segment |
-| Update | Modify broadcast settings |
-| Delete | Remove a broadcast |
-| List | List all broadcasts |
+| Operation | Description                   |
+| --------- | ----------------------------- |
+| Create    | Create an email campaign      |
+| Get       | Retrieve broadcast details    |
+| Send      | Send a broadcast to a segment |
+| Update    | Modify broadcast settings     |
+| Delete    | Remove a broadcast            |
+| List      | List all broadcasts           |
 
 ### Template
 
-| Operation | Description |
-|-----------|-------------|
-| Create | Create an email template |
-| Get | Retrieve template details |
-| Update | Modify a template |
-| Delete | Remove a template |
-| List | List all templates |
+| Operation | Description               |
+| --------- | ------------------------- |
+| Create    | Create an email template  |
+| Get       | Retrieve template details |
+| Update    | Modify a template         |
+| Delete    | Remove a template         |
+| List      | List all templates        |
 
 ### Domain
 
-| Operation | Description |
-|-----------|-------------|
-| Create | Add a sending domain |
-| Get | Retrieve domain details |
-| Verify | Trigger domain verification |
-| Update | Modify domain settings |
-| Delete | Remove a domain |
-| List | List all domains |
+| Operation | Description                 |
+| --------- | --------------------------- |
+| Create    | Add a sending domain        |
+| Get       | Retrieve domain details     |
+| Verify    | Trigger domain verification |
+| Update    | Modify domain settings      |
+| Delete    | Remove a domain             |
+| List      | List all domains            |
 
 ### API Key
 
-| Operation | Description |
-|-----------|-------------|
-| Create | Generate a new API key |
-| Delete | Revoke an API key |
-| List | List all API keys |
+| Operation | Description            |
+| --------- | ---------------------- |
+| Create    | Generate a new API key |
+| Delete    | Revoke an API key      |
+| List      | List all API keys      |
 
 ### Webhook
 
-| Operation | Description |
-|-----------|-------------|
-| Create | Create a webhook endpoint |
-| Get | Retrieve webhook details |
-| Update | Modify webhook settings |
-| Delete | Remove a webhook |
-| List | List all webhooks |
+| Operation | Description               |
+| --------- | ------------------------- |
+| Create    | Create a webhook endpoint |
+| Get       | Retrieve webhook details  |
+| Update    | Modify webhook settings   |
+| Delete    | Remove a webhook          |
+| List      | List all webhooks         |
 
 ## Trigger Events
 
 The **Resend Trigger** node receives webhooks for real-time email events. Signatures are automatically verified using Svix.
 
-| Event | Description |
-|-------|-------------|
-| `email.sent` | Email sent to recipient |
-| `email.delivered` | Email delivered successfully |
-| `email.delivery_delayed` | Email delivery delayed |
-| `email.opened` | Recipient opened the email |
-| `email.clicked` | Link clicked in email |
-| `email.bounced` | Email bounced |
-| `email.complained` | Spam complaint received |
-| `contact.created` | New contact added |
-| `contact.updated` | Contact modified |
-| `contact.deleted` | Contact removed |
-| `domain.created` | New domain added |
-| `domain.updated` | Domain modified |
-| `domain.deleted` | Domain removed |
+| Event                      | Description                  |
+| -------------------------- | ---------------------------- |
+| `email.sent`             | Email sent to recipient      |
+| `email.delivered`        | Email delivered successfully |
+| `email.delivery_delayed` | Email delivery delayed       |
+| `email.opened`           | Recipient opened the email   |
+| `email.clicked`          | Link clicked in email        |
+| `email.bounced`          | Email bounced                |
+| `email.complained`       | Spam complaint received      |
+| `contact.created`        | New contact added            |
+| `contact.updated`        | Contact modified             |
+| `contact.deleted`        | Contact removed              |
+| `domain.created`         | New domain added             |
+| `domain.updated`         | Domain modified              |
+| `domain.deleted`         | Domain removed               |
 
 ## Limitations
 


### PR DESCRIPTION
Added detailed table showing implementation status of all Resend API v1.1.0 endpoints:
- Full coverage: Email, Domains, API Keys, Contacts, Broadcasts, Topics, Contact Properties, Webhooks
- Partial coverage: Templates (missing Publish/Duplicate), Segments (missing Update)
- Not implemented: Email Attachments, Receiving Emails, Contact Segments/Topics management

Helps users quickly understand which Resend features are available in n8n.

<!-- GitButler Footer Boundary Top -->
---
This is **part 2 of 3 in a stack** made with GitButler:
- <kbd>&nbsp;3&nbsp;</kbd> #18 
- <kbd>&nbsp;2&nbsp;</kbd> #17 👈 
- <kbd>&nbsp;1&nbsp;</kbd> #16 
<!-- GitButler Footer Boundary Bottom -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added an API coverage table to the README for Resend API v1.1.0. It shows which endpoints the n8n Resend node supports and what’s missing.

- **New Features**
  - Full: Email, Domains, API Keys, Contacts, Broadcasts, Topics, Contact Properties, Webhooks.
  - Partial: Templates (missing Publish/Duplicate), Segments (missing Update, filter conditions).
  - Missing: Email Attachments, Receiving Emails, contact segments/topics management.

<sup>Written for commit 4d3390cf10a3c71f1a5515e9a71c779c9431a3bd. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->