### PR TITLE
refactor(resend): reformat code for line length and consistency

### DIFF
--- a/credentials/AGENTS.md
+++ b/credentials/AGENTS.md
@@ -1,10 +1,12 @@
 # AGENTS.md
 
 ## Package Identity
+
 - Defines the Resend API credential used by the nodes
 - Tech: TypeScript + n8n-workflow credential interfaces
 
 ## Setup & Run
+
 - Install deps: `npm install`
 - Build: `npm run build`
 - Dev watch: `npm run dev`
@@ -14,6 +16,7 @@
 - Tests: not configured
 
 ## Patterns & Conventions
+
 - DO: Follow the credential class pattern in `credentials/ResendApi.credentials.ts`.
 - DO: Keep `name = 'resendApi'` aligned with `nodes/Resend/Resend.node.ts`.
 - DO: Use `typeOptions: { password: true }` for secrets as in `credentials/ResendApi.credentials.ts`.
@@ -26,11 +29,13 @@
 - DO: Keep formatting consistent with tabs as shown in `credentials/ResendApi.credentials.ts`.
 
 ## Touch Points / Key Files
+
 - Credential definition: `credentials/ResendApi.credentials.ts`
 - Node reference to credential name: `nodes/Resend/Resend.node.ts`
 - n8n credential registration: `package.json`
 
 ## JIT Index Hints
+
 - Find credential classes: `rg -n "ICredentialType" credentials`
 - Find auth headers: `rg -n "authenticate" credentials/ResendApi.credentials.ts`
 - Find credential tests: `rg -n "test:" credentials/ResendApi.credentials.ts`
@@ -38,9 +43,11 @@
 - Find n8n credential registration: `rg -n "\"credentials\"" package.json`
 
 ## Common Gotchas
+
 - The credential `name` must stay `resendApi` to match `nodes/Resend/Resend.node.ts`.
 - `authenticate` and `test` are required by n8n ESLint rules; lint fails if missing.
 - Credential filenames must end in `.credentials.ts` to satisfy n8n ESLint rules.
 
 ## Pre-PR Checks
+
 - `npm run lint && npm run build`

--- a/credentials/ResendApi.credentials.ts
+++ b/credentials/ResendApi.credentials.ts
@@ -18,7 +18,8 @@ export class ResendApi implements ICredentialType {
 			default: '',
 			required: true,
 		},
-	];	authenticate: IAuthenticateGeneric = {
+	];
+	authenticate: IAuthenticateGeneric = {
 		type: 'generic',
 		properties: {
 			headers: {

--- a/nodes/Resend/AGENTS.md
+++ b/nodes/Resend/AGENTS.md
@@ -1,10 +1,12 @@
 # AGENTS.md
 
 ## Package Identity
+
 - Resend action node and webhook trigger for n8n
 - Tech: TypeScript + n8n-workflow node APIs
 
 ## Setup & Run
+
 - Install deps: `npm install`
 - Build: `npm run build`
 - Dev watch: `npm run dev`
@@ -14,6 +16,7 @@
 - Tests: not configured
 
 ## Patterns & Conventions
+
 - DO: Keep the main node description and properties in `nodes/Resend/Resend.node.ts`.
 - DO: Ensure `description` includes core fields (`displayName`, `name`, `icon`, `group`, `version`, `description`, `defaults`, `inputs`, `outputs`, `credentials`) as shown in `nodes/Resend/Resend.node.ts`.
 - DO: Implement resource/operation logic in the `execute` flow in `nodes/Resend/Resend.node.ts`.
@@ -27,6 +30,7 @@
 - DON'T: Revive `_audit/actuallyzefe-n8n-nodes-resend/nodes/Resend/Resend.node.json`; it is archived only.
 
 ## Touch Points / Key Files
+
 - Action node: `nodes/Resend/Resend.node.ts`
 - Trigger node: `nodes/Resend/ResendTrigger.node.ts`
 - Icons: `nodes/Resend/resend-icon-white.svg`
@@ -35,6 +39,7 @@
 - n8n node registration: `package.json`
 
 ## JIT Index Hints
+
 - Find resources/options: `rg -n "resource" nodes/Resend/Resend.node.ts`
 - Find operations: `rg -n "operation" nodes/Resend/Resend.node.ts`
 - Find API requests: `rg -n "helpers.httpRequest" nodes/Resend/Resend.node.ts`
@@ -43,9 +48,11 @@
 - Find signature verification: `rg -n "verifySvixSignature" nodes/Resend/ResendTrigger.node.ts`
 
 ## Common Gotchas
+
 - Attachments cannot be used with scheduled emails (guarded in `nodes/Resend/Resend.node.ts`).
 - Webhook verification expects `svix-*` headers; missing headers are ignored.
 - The `path` parameter is full path (`isFullPath: true`), so it replaces the UUID segment.
 
 ## Pre-PR Checks
+
 - `npm run lint && npm run build`

--- a/nodes/Resend/GenericFunctions.ts
+++ b/nodes/Resend/GenericFunctions.ts
@@ -64,9 +64,7 @@ const loadDropdownOptions = async (
 
 export const normalizeEmailList = (value: string | string[] | undefined) => {
 	if (Array.isArray(value)) {
-		return value
-			.map((email) => String(email).trim())
-			.filter((email) => email);
+		return value.map((email) => String(email).trim()).filter((email) => email);
 	}
 	if (typeof value === 'string') {
 		return value
@@ -79,7 +77,9 @@ export const normalizeEmailList = (value: string | string[] | undefined) => {
 
 export const parseTemplateVariables = (
 	executeFunctions: IExecuteFunctions,
-	variablesInput: { variables?: Array<{ key: string; type: string; fallbackValue?: unknown }> } | undefined,
+	variablesInput:
+		| { variables?: Array<{ key: string; type: string; fallbackValue?: unknown }> }
+		| undefined,
 	fallbackKey: 'fallbackValue' | 'fallback_value',
 	itemIndex: number,
 ) => {
@@ -97,7 +97,8 @@ export const parseTemplateVariables = (
 		if (fallbackValue !== undefined && fallbackValue !== '') {
 			let parsedFallback: string | number = fallbackValue as string;
 			if (variable.type === 'number') {
-				const numericFallback = typeof fallbackValue === 'number' ? fallbackValue : Number(fallbackValue);
+				const numericFallback =
+					typeof fallbackValue === 'number' ? fallbackValue : Number(fallbackValue);
 				if (Number.isNaN(numericFallback)) {
 					throw new NodeOperationError(
 						executeFunctions.getNode(),
@@ -266,20 +267,14 @@ export async function getTemplateVariables(
 		});
 }
 
-export async function getTemplates(
-	this: ILoadOptionsFunctions,
-): Promise<INodePropertyOptions[]> {
+export async function getTemplates(this: ILoadOptionsFunctions): Promise<INodePropertyOptions[]> {
 	return loadDropdownOptions(this, '/templates');
 }
 
-export async function getSegments(
-	this: ILoadOptionsFunctions,
-): Promise<INodePropertyOptions[]> {
+export async function getSegments(this: ILoadOptionsFunctions): Promise<INodePropertyOptions[]> {
 	return loadDropdownOptions(this, '/segments');
 }
 
-export async function getTopics(
-	this: ILoadOptionsFunctions,
-): Promise<INodePropertyOptions[]> {
+export async function getTopics(this: ILoadOptionsFunctions): Promise<INodePropertyOptions[]> {
 	return loadDropdownOptions(this, '/topics');
 }

--- a/nodes/Resend/ResendTrigger.node.ts
+++ b/nodes/Resend/ResendTrigger.node.ts
@@ -30,7 +30,10 @@ async function verifySvixSignature(
 ): Promise<void> {
 	const timestampMs = parseSvixTimestamp(svixTimestamp);
 	if (!timestampMs || Math.abs(Date.now() - timestampMs) > WEBHOOK_TOLERANCE_MS) {
-		throw new NodeOperationError(node, 'Webhook signature timestamp is outside the allowed tolerance');
+		throw new NodeOperationError(
+			node,
+			'Webhook signature timestamp is outside the allowed tolerance',
+		);
 	}
 
 	// Remove the "whsec_" prefix from the secret
@@ -51,7 +54,10 @@ async function verifySvixSignature(
 		const [version, signature] = sig.split(',');
 		if (version === 'v1') {
 			const signatureBytes = Buffer.from(signature, 'base64');
-			if (signatureBytes.length === expectedBytes.length && timingSafeEqual(signatureBytes, expectedBytes)) {
+			if (
+				signatureBytes.length === expectedBytes.length &&
+				timingSafeEqual(signatureBytes, expectedBytes)
+			) {
 				return; // Signature is valid
 			}
 		}
@@ -63,20 +69,27 @@ export class ResendTrigger implements INodeType {
 	description: INodeTypeDescription = {
 		displayName: 'Resend Trigger',
 		name: 'resendTrigger',
-		icon: 'file:resend-icon-white.svg',		group: ['trigger'],
+		icon: 'file:resend-icon-white.svg',
+		group: ['trigger'],
 		version: 1,
-		description: 'Triggers workflows when Resend email events occur, such as email sent, delivered, opened, clicked, bounced, or complained. Includes secure webhook signature verification.',
-		subtitle: '={{(() => { const events = $parameter["events"] ?? []; const actionLabels = { created: "create", deleted: "delete", updated: "update", sent: "send", opened: "open", clicked: "click", bounced: "bounce", complained: "complain", delivered: "deliver", delivery_delayed: "delay" }; return events.map((event) => { const [resource, action] = event.split("."); if (!resource || !action) { return event; } const actionLabel = actionLabels[action] ?? action.replace(/_/g, " "); return actionLabel + ": " + resource; }).join(", "); })() }}',
+		description:
+			'Triggers workflows when Resend email events occur, such as email sent, delivered, opened, clicked, bounced, or complained. Includes secure webhook signature verification.',
+		subtitle:
+			'={{(() => { const events = $parameter["events"] ?? []; const actionLabels = { created: "create", deleted: "delete", updated: "update", sent: "send", opened: "open", clicked: "click", bounced: "bounce", complained: "complain", delivered: "deliver", delivery_delayed: "delay" }; return events.map((event) => { const [resource, action] = event.split("."); if (!resource || !action) { return event; } const actionLabel = actionLabels[action] ?? action.replace(/_/g, " "); return actionLabel + ": " + resource; }).join(", "); })() }}',
 		defaults: {
 			name: 'Resend Trigger',
 		},
 		triggerPanel: {
-			header: 'Copy the webhook URL below and paste it into your Resend dashboard webhook configuration.',
+			header:
+				'Copy the webhook URL below and paste it into your Resend dashboard webhook configuration.',
 			executionsHelp: {
-				inactive: 'Webhooks have two modes: test and production.<br><br><b>Use test mode while you build your workflow</b>. Click the "Listen for test event" button, then paste the test URL into your Resend webhook configuration. The webhook executions will show up in the editor.<br><br><b>Use production mode to run your workflow automatically</b>. Activate the workflow, then paste the production URL into your Resend webhook configuration. These executions will show up in the executions list, but not in the editor.',
-				active: 'Webhooks have two modes: test and production.<br><br><b>Use test mode while you build your workflow</b>. Click the "Listen for test event" button, then paste the test URL into your Resend webhook configuration. The webhook executions will show up in the editor.<br><br><b>Use production mode to run your workflow automatically</b>. Since the workflow is activated, you can paste the production URL into your Resend webhook configuration. These executions will show up in the executions list, but not in the editor.',
+				inactive:
+					'Webhooks have two modes: test and production.<br><br><b>Use test mode while you build your workflow</b>. Click the "Listen for test event" button, then paste the test URL into your Resend webhook configuration. The webhook executions will show up in the editor.<br><br><b>Use production mode to run your workflow automatically</b>. Activate the workflow, then paste the production URL into your Resend webhook configuration. These executions will show up in the executions list, but not in the editor.',
+				active:
+					'Webhooks have two modes: test and production.<br><br><b>Use test mode while you build your workflow</b>. Click the "Listen for test event" button, then paste the test URL into your Resend webhook configuration. The webhook executions will show up in the editor.<br><br><b>Use production mode to run your workflow automatically</b>. Since the workflow is activated, you can paste the production URL into your Resend webhook configuration. These executions will show up in the executions list, but not in the editor.',
 			},
-			activationHint: 'Once you\'ve finished building your workflow, activate it to use the production webhook URL in your Resend dashboard.',
+			activationHint:
+				"Once you've finished building your workflow, activate it to use the production webhook URL in your Resend dashboard.",
 		},
 		inputs: [],
 		outputs: ['main' as NodeConnectionType],
@@ -89,49 +102,54 @@ export class ResendTrigger implements INodeType {
 				isFullPath: true,
 			},
 		],
-		properties: [{
-			displayName: 'Path',
-			name: 'path',
-			type: 'string',
-			default: 'resend',
-			placeholder: 'resend',
-			required: true,
-			description: 'The path for the webhook URL. This will completely replace the UUID segment in the webhook URL. For example, if you set this to "test1", your webhook URL will be https://your-n8n-domain/webhook-test/test1',
-		},		{
-			displayName: 'Webhook Signing Secret',
-			name: 'webhookSigningSecret',
-			type: 'string',
-			placeholder: 'whsec_...',
-			required: true,
-			typeOptions: { password: true },
+		properties: [
+			{
+				displayName: 'Path',
+				name: 'path',
+				type: 'string',
+				default: 'resend',
+				placeholder: 'resend',
+				required: true,
+				description:
+					'The path for the webhook URL. This will completely replace the UUID segment in the webhook URL. For example, if you set this to "test1", your webhook URL will be https://your-n8n-domain/webhook-test/test1',
+			},
+			{
+				displayName: 'Webhook Signing Secret',
+				name: 'webhookSigningSecret',
+				type: 'string',
+				placeholder: 'whsec_...',
+				required: true,
+				typeOptions: { password: true },
 
-			default: '',
-			description: 'Found in your Resend webhook configuration page (whsec_... value).',
-		},
-		{
-			displayName: 'Events',
-			name: 'events',
-			type: 'multiOptions',
-			required: true,
-			default: ['email.sent'], options: [
-				{ name: 'Contact Created', value: 'contact.created' },
-				{ name: 'Contact Deleted', value: 'contact.deleted' },
-				{ name: 'Contact Updated', value: 'contact.updated' },
-				{ name: 'Domain Created', value: 'domain.created' },
-				{ name: 'Domain Deleted', value: 'domain.deleted' },
-				{ name: 'Domain Updated', value: 'domain.updated' },
-				{ name: 'Email Bounced', value: 'email.bounced' },
-				{ name: 'Email Clicked', value: 'email.clicked' },
-				{ name: 'Email Complained', value: 'email.complained' },
-				{ name: 'Email Delivered', value: 'email.delivered' },
-				{ name: 'Email Delivery Delayed', value: 'email.delivery_delayed' },
-				{ name: 'Email Opened', value: 'email.opened' },
-				{ name: 'Email Sent', value: 'email.sent' },
-			],
-			description: 'Select the Resend event types to listen for',
-		},
+				default: '',
+				description: 'Found in your Resend webhook configuration page (whsec_... value).',
+			},
+			{
+				displayName: 'Events',
+				name: 'events',
+				type: 'multiOptions',
+				required: true,
+				default: ['email.sent'],
+				options: [
+					{ name: 'Contact Created', value: 'contact.created' },
+					{ name: 'Contact Deleted', value: 'contact.deleted' },
+					{ name: 'Contact Updated', value: 'contact.updated' },
+					{ name: 'Domain Created', value: 'domain.created' },
+					{ name: 'Domain Deleted', value: 'domain.deleted' },
+					{ name: 'Domain Updated', value: 'domain.updated' },
+					{ name: 'Email Bounced', value: 'email.bounced' },
+					{ name: 'Email Clicked', value: 'email.clicked' },
+					{ name: 'Email Complained', value: 'email.complained' },
+					{ name: 'Email Delivered', value: 'email.delivered' },
+					{ name: 'Email Delivery Delayed', value: 'email.delivery_delayed' },
+					{ name: 'Email Opened', value: 'email.opened' },
+					{ name: 'Email Sent', value: 'email.sent' },
+				],
+				description: 'Select the Resend event types to listen for',
+			},
 		],
-	}; async webhook(this: IWebhookFunctions): Promise<IWebhookResponseData> {
+	};
+	async webhook(this: IWebhookFunctions): Promise<IWebhookResponseData> {
 		const bodyData = this.getBodyData();
 		const headers = this.getHeaderData();
 		const request = this.getRequestObject();
@@ -141,20 +159,36 @@ export class ResendTrigger implements INodeType {
 		if (webhookSigningSecret && webhookSigningSecret.trim() !== '') {
 			try {
 				// Get the raw body for signature verification
-				const rawBody = (request as { rawBody?: unknown }).rawBody ?? (request as { body?: unknown }).body;
-				const payload = typeof rawBody === 'string'
-					? rawBody
-					: Buffer.isBuffer(rawBody)
-						? rawBody.toString('utf8')
-						: JSON.stringify(bodyData ?? {});
+				const rawBody =
+					(request as { rawBody?: unknown }).rawBody ?? (request as { body?: unknown }).body;
+				const payload =
+					typeof rawBody === 'string'
+						? rawBody
+						: Buffer.isBuffer(rawBody)
+							? rawBody.toString('utf8')
+							: JSON.stringify(bodyData ?? {});
 
 				// Extract Svix headers with proper type handling
-				const svixId = (Array.isArray(headers['svix-id']) ? headers['svix-id'][0] : headers['svix-id']) ||
-					(Array.isArray(headers['Svix-Id']) ? headers['Svix-Id'][0] : headers['Svix-Id']) || '';
-				const svixTimestamp = (Array.isArray(headers['svix-timestamp']) ? headers['svix-timestamp'][0] : headers['svix-timestamp']) ||
-					(Array.isArray(headers['Svix-Timestamp']) ? headers['Svix-Timestamp'][0] : headers['Svix-Timestamp']) || '';
-				const svixSignature = (Array.isArray(headers['svix-signature']) ? headers['svix-signature'][0] : headers['svix-signature']) ||
-					(Array.isArray(headers['Svix-Signature']) ? headers['Svix-Signature'][0] : headers['Svix-Signature']) || '';
+				const svixId =
+					(Array.isArray(headers['svix-id']) ? headers['svix-id'][0] : headers['svix-id']) ||
+					(Array.isArray(headers['Svix-Id']) ? headers['Svix-Id'][0] : headers['Svix-Id']) ||
+					'';
+				const svixTimestamp =
+					(Array.isArray(headers['svix-timestamp'])
+						? headers['svix-timestamp'][0]
+						: headers['svix-timestamp']) ||
+					(Array.isArray(headers['Svix-Timestamp'])
+						? headers['Svix-Timestamp'][0]
+						: headers['Svix-Timestamp']) ||
+					'';
+				const svixSignature =
+					(Array.isArray(headers['svix-signature'])
+						? headers['svix-signature'][0]
+						: headers['svix-signature']) ||
+					(Array.isArray(headers['Svix-Signature'])
+						? headers['Svix-Signature'][0]
+						: headers['Svix-Signature']) ||
+					'';
 
 				if (!svixId || !svixTimestamp || !svixSignature) {
 					console.error('Missing required Svix headers for webhook verification');
@@ -164,7 +198,14 @@ export class ResendTrigger implements INodeType {
 				}
 
 				// Verify the webhook signature
-				await verifySvixSignature(payload, svixId, svixTimestamp, svixSignature, webhookSigningSecret, this.getNode());
+				await verifySvixSignature(
+					payload,
+					svixId,
+					svixTimestamp,
+					svixSignature,
+					webhookSigningSecret,
+					this.getNode(),
+				);
 			} catch (error) {
 				// Signature verification failed
 				console.error('Resend webhook signature verification failed:', error);

--- a/nodes/Resend/descriptions/ApiKeyDescription.ts
+++ b/nodes/Resend/descriptions/ApiKeyDescription.ts
@@ -100,6 +100,7 @@ export const apiKeyFields: INodeProperties[] = [
 				permission: ['sending_access'],
 			},
 		},
-		description: 'Restrict an API key to send emails only from a specific domain. This is only used when the permission is set to sending access.',
+		description:
+			'Restrict an API key to send emails only from a specific domain. This is only used when the permission is set to sending access.',
 	},
 ];

--- a/nodes/Resend/descriptions/BroadcastDescription.ts
+++ b/nodes/Resend/descriptions/BroadcastDescription.ts
@@ -99,7 +99,8 @@ export const broadcastFields: INodeProperties[] = [
 				operation: ['create'],
 			},
 		},
-		description: 'Sender email address. To include a friendly name, use the format "Your Name &lt;sender@domain.com&gt;".',
+		description:
+			'Sender email address. To include a friendly name, use the format "Your Name &lt;sender@domain.com&gt;".',
 	},
 	{
 		displayName: 'Subject',
@@ -125,14 +126,16 @@ export const broadcastFields: INodeProperties[] = [
 		typeOptions: {
 			multiline: true,
 		},
-		placeholder: '<p>Your HTML content here with {{{FIRST_NAME|there}}} and {{{RESEND_UNSUBSCRIBE_URL}}}</p>',
+		placeholder:
+			'<p>Your HTML content here with {{{FIRST_NAME|there}}} and {{{RESEND_UNSUBSCRIBE_URL}}}</p>',
 		displayOptions: {
 			show: {
 				resource: ['broadcasts'],
 				operation: ['create'],
 			},
 		},
-		description: 'The HTML version of the message. You can use variables like {{{FIRST_NAME|fallback}}} and {{{RESEND_UNSUBSCRIBE_URL}}}.',
+		description:
+			'The HTML version of the message. You can use variables like {{{FIRST_NAME|fallback}}} and {{{RESEND_UNSUBSCRIBE_URL}}}.',
 	},
 	{
 		displayName: 'Create Options',

--- a/nodes/Resend/descriptions/DomainDescription.ts
+++ b/nodes/Resend/descriptions/DomainDescription.ts
@@ -157,7 +157,8 @@ export const domainFields: INodeProperties[] = [
 					{ name: 'Enforced', value: 'enforced' },
 				],
 				default: 'opportunistic',
-				description: 'TLS setting for email delivery. Opportunistic attempts secure connection but falls back to unencrypted if needed. Enforced requires TLS and will not send if unavailable.',
+				description:
+					'TLS setting for email delivery. Opportunistic attempts secure connection but falls back to unencrypted if needed. Enforced requires TLS and will not send if unavailable.',
 			},
 		],
 	},

--- a/nodes/Resend/descriptions/EmailDescription.ts
+++ b/nodes/Resend/descriptions/EmailDescription.ts
@@ -69,7 +69,8 @@ export const emailFields: INodeProperties[] = [
 				operation: ['send'],
 			},
 		},
-		description: 'Sender email address. To include a friendly name, use the format "Your Name &lt;sender@domain.com&gt;".',
+		description:
+			'Sender email address. To include a friendly name, use the format "Your Name &lt;sender@domain.com&gt;".',
 	},
 	{
 		displayName: 'To',
@@ -143,7 +144,8 @@ export const emailFields: INodeProperties[] = [
 				useTemplate: [false],
 			},
 		},
-		description: 'Choose the format for your email content. HTML allows rich formatting, text is simple and universally compatible.',
+		description:
+			'Choose the format for your email content. HTML allows rich formatting, text is simple and universally compatible.',
 	},
 	{
 		displayName: 'Template Name or ID',
@@ -162,7 +164,8 @@ export const emailFields: INodeProperties[] = [
 				useTemplate: [true],
 			},
 		},
-		description: 'Select a template or enter an ID/alias using an expression. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+		description:
+			'Select a template or enter an ID/alias using an expression. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
 	},
 	{
 		displayName: 'Template Variables',
@@ -196,7 +199,8 @@ export const emailFields: INodeProperties[] = [
 							loadOptionsDependsOn: ['emailTemplateId'],
 							allowCustomValues: true,
 						},
-						description: 'Template variable name. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+						description:
+							'Template variable name. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
 					},
 					{
 						displayName: 'Value',
@@ -544,7 +548,8 @@ export const emailFields: INodeProperties[] = [
 												type: 'string',
 												default: '',
 												placeholder: 'document.pdf',
-												description: 'Name for the attached file (required for both binary data and URL)',
+												description:
+													'Name for the attached file (required for both binary data and URL)',
 											},
 											{
 												displayName: 'File URL',
@@ -584,26 +589,26 @@ export const emailFields: INodeProperties[] = [
 								type: 'fixedCollection',
 								default: {},
 								options: [
+									{
+										name: 'headers',
+										displayName: 'Header',
+										values: [
 											{
-												name: 'headers',
-												displayName: 'Header',
-													values:	[
-													{
-														displayName: 'Name',
-														name: 'name',
-														type: 'string',
-															required:	true,
-														default: '',
-													},
-													{
-														displayName: 'Value',
-														name: 'value',
-														type: 'string',
-														default: '',
-													},
-													]
+												displayName: 'Name',
+												name: 'name',
+												type: 'string',
+												required: true,
+												default: '',
 											},
-									],
+											{
+												displayName: 'Value',
+												name: 'value',
+												type: 'string',
+												default: '',
+											},
+										],
+									},
+								],
 								description: 'Custom headers to add to the email',
 							},
 							{
@@ -611,7 +616,8 @@ export const emailFields: INodeProperties[] = [
 								name: 'reply_to',
 								type: 'string',
 								default: '',
-								description: 'Reply-to email address. For multiple addresses, use comma-separated values.',
+								description:
+									'Reply-to email address. For multiple addresses, use comma-separated values.',
 							},
 							{
 								displayName: 'Tags',
@@ -619,27 +625,27 @@ export const emailFields: INodeProperties[] = [
 								type: 'fixedCollection',
 								default: {},
 								options: [
+									{
+										name: 'tags',
+										displayName: 'Tag',
+										values: [
 											{
-												name: 'tags',
-												displayName: 'Tag',
-													values:	[
-													{
-														displayName: 'Name',
-														name: 'name',
-														type: 'string',
-															required:	true,
-														default: '',
-													},
-													{
-														displayName: 'Value',
-														name: 'value',
-														type: 'string',
-															required:	true,
-														default: '',
-													},
-													]
+												displayName: 'Name',
+												name: 'name',
+												type: 'string',
+												required: true,
+												default: '',
 											},
-									],
+											{
+												displayName: 'Value',
+												name: 'value',
+												type: 'string',
+												required: true,
+												default: '',
+											},
+										],
+									},
+								],
 								description: 'Tags to attach to the email',
 							},
 							{
@@ -649,7 +655,7 @@ export const emailFields: INodeProperties[] = [
 								default: '',
 								description: 'Topic ID to scope the email to',
 							},
-					]
+						],
 					},
 					{
 						displayName: 'Email Format',
@@ -671,15 +677,16 @@ export const emailFields: INodeProperties[] = [
 								value: 'text',
 								description: 'Send email with plain text content',
 							},
-					],
+						],
 						default: 'html',
-						description: 'Choose the format for your email content. HTML allows rich formatting, text is simple and universally compatible.',
+						description:
+							'Choose the format for your email content. HTML allows rich formatting, text is simple and universally compatible.',
 					},
 					{
 						displayName: 'From',
 						name: 'from',
 						type: 'string',
-							required:	true,
+						required: true,
 						default: '',
 						placeholder: 'you@example.com',
 						description: 'Sender email address',
@@ -696,7 +703,7 @@ export const emailFields: INodeProperties[] = [
 						displayName: 'Subject',
 						name: 'subject',
 						type: 'string',
-							required:	true,
+						required: true,
 						default: '',
 						placeholder: 'Hello from n8n!',
 						description: 'Email subject',
@@ -705,10 +712,11 @@ export const emailFields: INodeProperties[] = [
 						displayName: 'Template Name or ID',
 						name: 'templateId',
 						type: 'options',
-							required:	true,
+						required: true,
 						default: '',
 						placeholder: '34a080c9-b17d-4187-ad80-5af20266e535',
-						description: 'Select a template or enter an ID/alias using an expression. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+						description:
+							'Select a template or enter an ID/alias using an expression. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
 					},
 					{
 						displayName: 'Template Variables',
@@ -720,25 +728,25 @@ export const emailFields: INodeProperties[] = [
 							{
 								name: 'variables',
 								displayName: 'Variable',
-									values:	[
-											{
-												displayName: 'Key',
-												name: 'key',
-												type: 'options',
-													required:	true,
-												default: '',
-												description: 'Template variable name',
-											},
-											{
-												displayName: 'Value',
-												name: 'value',
-												type: 'string',
-												default: '',
-												description: 'Value for the template variable',
-											},
-									]
+								values: [
+									{
+										displayName: 'Key',
+										name: 'key',
+										type: 'options',
+										required: true,
+										default: '',
+										description: 'Template variable name',
+									},
+									{
+										displayName: 'Value',
+										name: 'value',
+										type: 'string',
+										default: '',
+										description: 'Value for the template variable',
+									},
+								],
 							},
-					]
+						],
 					},
 					{
 						displayName: 'Text Content',
@@ -752,7 +760,7 @@ export const emailFields: INodeProperties[] = [
 						displayName: 'To',
 						name: 'to',
 						type: 'string',
-							required:	true,
+						required: true,
 						default: '',
 						placeholder: 'user@example.com',
 						description: 'Recipient email address (comma-separated for multiple)',
@@ -764,7 +772,7 @@ export const emailFields: INodeProperties[] = [
 						default: false,
 						description: 'Whether to send using a published template instead of HTML/Text content',
 					},
-			],
+				],
 			},
 		],
 	},
@@ -838,7 +846,8 @@ export const emailFields: INodeProperties[] = [
 				operation: ['update'],
 			},
 		},
-		description: 'Schedule email to be sent later. The date should be in ISO 8601 format (e.g., 2024-08-05T11:52:01.858Z).',
+		description:
+			'Schedule email to be sent later. The date should be in ISO 8601 format (e.g., 2024-08-05T11:52:01.858Z).',
 	},
 	{
 		displayName: 'Return All',
@@ -847,7 +856,18 @@ export const emailFields: INodeProperties[] = [
 		default: false,
 		displayOptions: {
 			show: {
-				resource: ['email', 'templates', 'domains', 'apiKeys', 'broadcasts', 'segments', 'topics', 'contacts', 'webhooks', 'contactProperties'],
+				resource: [
+					'email',
+					'templates',
+					'domains',
+					'apiKeys',
+					'broadcasts',
+					'segments',
+					'topics',
+					'contacts',
+					'webhooks',
+					'contactProperties',
+				],
 				operation: ['list'],
 			},
 		},
@@ -863,7 +883,18 @@ export const emailFields: INodeProperties[] = [
 		default: 50,
 		displayOptions: {
 			show: {
-				resource: ['email', 'templates', 'domains', 'apiKeys', 'broadcasts', 'segments', 'topics', 'contacts', 'webhooks', 'contactProperties'],
+				resource: [
+					'email',
+					'templates',
+					'domains',
+					'apiKeys',
+					'broadcasts',
+					'segments',
+					'topics',
+					'contacts',
+					'webhooks',
+					'contactProperties',
+				],
 				operation: ['list'],
 				returnAll: [false],
 			},

--- a/nodes/Resend/descriptions/SegmentDescription.ts
+++ b/nodes/Resend/descriptions/SegmentDescription.ts
@@ -75,6 +75,7 @@ export const segmentFields: INodeProperties[] = [
 				operation: ['get', 'delete'],
 			},
 		},
-		description: 'Select a segment or enter an ID using an expression. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+		description:
+			'Select a segment or enter an ID using an expression. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
 	},
 ];

--- a/nodes/Resend/descriptions/TemplateDescription.ts
+++ b/nodes/Resend/descriptions/TemplateDescription.ts
@@ -78,7 +78,8 @@ export const templateFields: INodeProperties[] = [
 				operation: ['create'],
 			},
 		},
-		description: 'Sender email address. To include a friendly name, use the format "Your Name &lt;sender@domain.com&gt;".',
+		description:
+			'Sender email address. To include a friendly name, use the format "Your Name &lt;sender@domain.com&gt;".',
 	},
 	{
 		displayName: 'Subject',
@@ -180,7 +181,8 @@ export const templateFields: INodeProperties[] = [
 				operation: ['get', 'update', 'delete'],
 			},
 		},
-		description: 'Select a template or enter an ID/alias using an expression. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+		description:
+			'Select a template or enter an ID/alias using an expression. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
 	},
 	{
 		displayName: 'Update Fields',
@@ -250,7 +252,8 @@ export const templateFields: INodeProperties[] = [
 					multiline: true,
 					rows: 4,
 				},
-				description: 'Plain text content. Set to an empty string to disable automatic plain text generation.',
+				description:
+					'Plain text content. Set to an empty string to disable automatic plain text generation.',
 			},
 		],
 	},

--- a/nodes/Resend/descriptions/TopicDescription.ts
+++ b/nodes/Resend/descriptions/TopicDescription.ts
@@ -132,7 +132,8 @@ export const topicFields: INodeProperties[] = [
 				operation: ['get', 'update', 'delete'],
 			},
 		},
-		description: 'Select a topic or enter an ID using an expression. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+		description:
+			'Select a topic or enter an ID using an expression. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
 	},
 	{
 		displayName: 'Update Fields',


### PR DESCRIPTION
Wrap long string literals and template strings to improve line
length consistency and readability across Resend node files.
Normalize array mapping return to a single-line expression in
normalizeEmailList to reduce visual noise. Adjust TypeScript
function signatures and parameter formatting for consistent
line wrapping (parseTemplateVariables, numericFallback, and
loaders getTemplates/getSegments/getTopics). Align options array
formatting in Resend.node to match surrounding style.

These changes are purely formatting and do not alter behavior.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refactored Resend nodes and trigger to enforce line-length and style consistency for better readability. No behavior changes.

- **Refactors**
  - Wrapped long strings and template literals across node and description files.
  - Standardized function signatures and parameter formatting (parseTemplateVariables, numeric fallback, dropdown loaders).
  - Simplified normalizeEmailList mapping/filtering to a single-line expression.
  - Aligned options array formatting in Resend.node and ResendTrigger.node to match project style.

<sup>Written for commit a5806d99f41fe25dc279a0fccff01c5bd507221f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

