### PR TITLE
feat(release): avoid redundant version commits and allow tag creation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,19 +40,28 @@ jobs:
             exit 1
           fi
 
-          # Update package.json version
-          npm version "${{ github.event.inputs.version }}" --no-git-tag-version
+          # Check current version
+          CURRENT_VERSION=$(node -p 'require("./package.json").version')
+          TARGET_VERSION="${{ github.event.inputs.version }}"
 
-          # Verify the change
-          NEW_VERSION=$(node -p 'require("./package.json").version')
-          echo "Package version updated to: $NEW_VERSION"
+          if [[ "$CURRENT_VERSION" == "$TARGET_VERSION" ]]; then
+            echo "Version is already set to $TARGET_VERSION - no update needed"
+          else
+            echo "Updating version from $CURRENT_VERSION to $TARGET_VERSION"
+            # Update package.json version
+            npm version "$TARGET_VERSION" --no-git-tag-version
 
-          # Commit the version change
-          git config --local user.email "action@github.com"
-          git config --local user.name "GitHub Action"
-          git add package.json package-lock.json
-          git commit -m "Bump version to ${{ github.event.inputs.version }}" || echo "No changes to commit"
-          git push origin ${{ github.ref_name }}
+            # Verify the change
+            NEW_VERSION=$(node -p 'require("./package.json").version')
+            echo "Package version updated to: $NEW_VERSION"
+
+            # Commit the version change
+            git config --local user.email "action@github.com"
+            git config --local user.name "GitHub Action"
+            git add package.json package-lock.json
+            git commit -m "Bump version to $TARGET_VERSION"
+            git push origin ${{ github.ref_name }}
+          fi
 
       - name: Install Dependencies
         run: npm ci
@@ -100,7 +109,7 @@ jobs:
     needs: validate-release
     environment: production
     permissions:
-      contents: read
+      contents: write # Required for creating tags and releases
       id-token: write # Required for npm provenance
 
     steps:


### PR DESCRIPTION
Check current package.json version before running npm version and only
perform the update, commit and push when the target version differs from
the current one. This prevents no-op commits when the version is already
set.

Also change workflow permissions for the production release job to give
contents: write so the action can create tags and GitHub Releases (and
support npm provenance).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents no-op version commits in the release workflow and enables tag and GitHub Release creation. Improves release consistency and supports npm provenance.

- **Refactors**
  - Only bump, commit, and push the version when it differs from package.json.

- **New Features**
  - Set contents: write for the production release job to create tags and GitHub Releases (supports npm provenance).

<sup>Written for commit 098e44689cdb900baa49a92cef9153a27e4794a6. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

