### PR TITLE
chore(ci): remove explicit npm registry url from workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,7 +26,6 @@ jobs:
         with:
           node-version: "20.x"
           cache: "npm"
-          registry-url: "https://registry.npmjs.org"
 
       - name: Update Package Version
         if: github.event_name == 'workflow_dispatch' && github.event.inputs.version != ''


### PR DESCRIPTION
Remove the hardcoded "registry-url" setting from the release workflow.
The Node setup action already uses the default npm registry, and keeping
an explicit URL was redundant and caused potential duplication or
confusion. This simplifies the workflow file and reduces maintenance.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed the hardcoded npm registry-url from the release workflow to rely on actions/setup-node defaults. Simplifies the workflow and avoids redundant configuration.

<sup>Written for commit 37e5aed233d1987c819afd31a829edfa61d15a52. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

