### PR TITLE
fix(pkg): correct repository URL and update release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -127,7 +127,9 @@ jobs:
         with:
           node-version: "20.x"
           cache: "npm"
-          registry-url: "https://registry.npmjs.org"
+
+      - name: Update npm to latest
+        run: npm install -g npm@latest
 
       - name: Install Dependencies
         run: npm ci

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/SilkePilon/n8n-nodes-resend/"
+    "url": "git+https://github.com/SilkePilon/n8n-nodes-resend.git"
   },
   "engines": {
     "node": ">=20.15"


### PR DESCRIPTION
Update package.json repository URL to use the canonical git+https
format with .git suffix so npm and other tools correctly resolve the
repository location.

Improve the GitHub Actions release workflow by installing the latest
npm before installing dependencies. This ensures CI uses a current npm
version and avoids issues with older bundled npm behavior during the
release job.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix the repository URL and make the release job more reliable. package.json now uses git+https with a .git suffix so npm resolves the repo, and the workflow installs the latest npm before npm ci to avoid issues with older npm.

<sup>Written for commit 9cd5a5e4ca6119c4a15f9901b89530de9912f0f6. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

