### PR TITLE
feat(ui): add light/dark Resend icons for nodes

### DIFF
--- a/nodes/Resend/Resend.node.ts
+++ b/nodes/Resend/Resend.node.ts
@@ -44,7 +44,10 @@ export class Resend implements INodeType {
 	description: INodeTypeDescription = {
 		displayName: 'Resend',
 		name: 'resend',
-		icon: 'file:resend-icon-white.svg',
+		icon: {
+			light: 'file:resend-icon-black.svg',
+			dark: 'file:resend-icon-white.svg',
+		},
 		group: ['output'],
 		version: 1,
 		description:

--- a/nodes/Resend/ResendTrigger.node.ts
+++ b/nodes/Resend/ResendTrigger.node.ts
@@ -69,7 +69,10 @@ export class ResendTrigger implements INodeType {
 	description: INodeTypeDescription = {
 		displayName: 'Resend Trigger',
 		name: 'resendTrigger',
-		icon: 'file:resend-icon-white.svg',
+		icon: {
+			light: 'file:resend-icon-black.svg',
+			dark: 'file:resend-icon-white.svg',
+		},
 		group: ['trigger'],
 		version: 1,
 		description:


### PR DESCRIPTION
Update Resend and Resend Trigger node descriptors to support both
light and dark icon variants instead of a single static icon path.
Replace the previous icon string with an icon object containing
light and dark keys so the UI can choose the appropriate asset
depending on theme.

This improves visual contrast and consistency across light and
dark themes.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add theme-aware icons to the Resend and Resend Trigger nodes to improve contrast in light and dark modes. Replace the single icon path with an icon object (light, dark) so the UI selects the correct asset per theme.

<sup>Written for commit a80da9d9add98c494f0b757d4bf54a3e5e703f51. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Resend integration icons now dynamically display theme-appropriate variants, switching between light and dark icons based on the current application theme

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->