### PR TITLE
chore(funding): remove GitHub sponsor file

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,1 +1,0 @@
-github: SilkePilon


### PR DESCRIPTION
Remove the GitHub sponsor file

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed .github/FUNDING.yml to disable the GitHub Sponsors button on the repository. No runtime or build impact.

<sup>Written for commit cf1b47dae0048aeb6e236e6468ffd74178393642. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

