### PR TITLE
feat(resend): add audience, segments, topics, and attachments ops

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,23 +28,20 @@ A community node for [n8n](https://n8n.io) that integrates with the [Resend](htt
 
 Comprehensive coverage of the Resend API (v1.1.0). The table below shows which endpoints are currently implemented:
 
-| API Resource                 | Endpoint                                   | Status          | Operations                                                      |
-| ---------------------------- | ------------------------------------------ | --------------- | --------------------------------------------------------------- |
-| **Email**              | `/emails`                                | ✅ Full         | Send, Send Batch, List, Get, Update, Cancel                     |
-| **Email Attachments**  | `/emails/{id}/attachments`               | ❌ Missing      | List attachments, Get attachment                                |
-| **Receiving Emails**   | `/emails/receiving`                      | ❌ Missing      | List received, Get received, Get attachments                    |
-| **Domains**            | `/domains`                               | ✅ Full         | Create, List, Get, Update, Delete, Verify                       |
-| **API Keys**           | `/api-keys`                              | ✅ Full         | Create, List, Delete                                            |
-| **Templates**          | `/templates`                             | ⚠️ Partial    | Create, List, Get, Update, Delete (Missing: Publish, Duplicate) |
-| **Audiences**          | `/audiences`                             | ⚠️ Deprecated | Replaced by Segments in v2.0.0                                  |
-| **Contacts**           | `/audiences/{id}/contacts`               | ✅ Full         | Create, List, Get, Update, Delete                               |
-| **Contact Segments**   | `/audiences/{id}/contacts/{id}/segments` | ❌ Missing      | Add to segment, List segments, Remove from segment              |
-| **Contact Topics**     | `/audiences/{id}/contacts/{id}/topics`   | ❌ Missing      | Get topics, Update topics                                       |
-| **Broadcasts**         | `/broadcasts`                            | ✅ Full         | Create, List, Get, Update, Delete, Send                         |
-| **Segments**           | `/segments`                              | ⚠️ Partial    | Create, List, Get, Delete (Missing: Update, Filter conditions)  |
-| **Topics**             | `/topics`                                | ✅ Full         | Create, List, Get, Update, Delete                               |
-| **Contact Properties** | `/contact-properties`                    | ✅ Full         | Create, List, Get, Update, Delete                               |
-| **Webhooks**           | `/webhooks`                              | ✅ Full         | Create, List, Get, Update, Delete                               |
+| API Resource           | Endpoint                   | Status     | Operations                                                                                                       |
+| ---------------------- | -------------------------- | ---------- | ---------------------------------------------------------------------------------------------------------------- |
+| **Email**              | `/emails`                  | ✅ Full    | Send, Send Batch, List, Get, Update, Cancel, List Attachments, Get Attachment                                    |
+| **Receiving Emails**   | `/emails/receiving`        | ✅ Full    | List, Get, List Attachments, Get Attachment                                                                      |
+| **Domains**            | `/domains`                 | ✅ Full    | Create, List, Get, Update, Delete, Verify                                                                        |
+| **API Keys**           | `/api-keys`                | ✅ Full    | Create, List, Delete                                                                                             |
+| **Templates**          | `/templates`               | ✅ Full    | Create, List, Get, Update, Delete, Publish, Duplicate                                                            |
+| **Audiences**          | `/audiences`               | ✅ Full    | Create, List, Get, Delete                                                                                        |
+| **Contacts**           | `/audiences/{id}/contacts` | ✅ Full    | Create, List, Get, Update, Delete, Add to Segment, List Segments, Remove from Segment, Get Topics, Update Topics |
+| **Broadcasts**         | `/broadcasts`              | ✅ Full    | Create, List, Get, Update, Delete, Send                                                                          |
+| **Segments**           | `/segments`                | ⚠️ Partial | Create, List, Get, Delete (Missing: Update, Filter conditions)                                                   |
+| **Topics**             | `/topics`                  | ✅ Full    | Create, List, Get, Update, Delete                                                                                |
+| **Contact Properties** | `/contact-properties`      | ✅ Full    | Create, List, Get, Update, Delete                                                                                |
+| **Webhooks**           | `/webhooks`                | ✅ Full    | Create, List, Get, Update, Delete                                                                                |
 
 ## Installation
 
@@ -81,24 +78,49 @@ docker run -it --rm \
 
 ### Email
 
-| Operation  | Description                                   |
-| ---------- | --------------------------------------------- |
-| Send       | Send a single email with optional attachments |
-| Send Batch | Send up to 100 emails in one request          |
-| List       | List sent emails                              |
-| Get        | Retrieve email details and status             |
-| Cancel     | Cancel a scheduled email                      |
-| Update     | Modify a scheduled email                      |
+| Operation        | Description                                   |
+| ---------------- | --------------------------------------------- |
+| Send             | Send a single email with optional attachments |
+| Send Batch       | Send up to 100 emails in one request          |
+| List             | List sent emails                              |
+| Get              | Retrieve email details and status             |
+| Cancel           | Cancel a scheduled email                      |
+| Update           | Modify a scheduled email                      |
+| List Attachments | List attachments for a sent email             |
+| Get Attachment   | Get a specific attachment from a sent email   |
+
+### Receiving Email
+
+| Operation        | Description                                     |
+| ---------------- | ----------------------------------------------- |
+| List             | List all received emails                        |
+| Get              | Retrieve a received email by ID                 |
+| List Attachments | List attachments for a received email           |
+| Get Attachment   | Get a specific attachment from a received email |
+
+### Audience
+
+| Operation | Description             |
+| --------- | ----------------------- |
+| Create    | Create a new audience   |
+| Get       | Retrieve audience by ID |
+| Delete    | Delete an audience      |
+| List      | List all audiences      |
 
 ### Contact
 
-| Operation | Description                |
-| --------- | -------------------------- |
-| Create    | Add a new contact          |
-| Get       | Retrieve contact details   |
-| Update    | Modify contact information |
-| Delete    | Remove a contact           |
-| List      | List all contacts          |
+| Operation           | Description                              |
+| ------------------- | ---------------------------------------- |
+| Create              | Add a new contact                        |
+| Get                 | Retrieve contact details                 |
+| Update              | Modify contact information               |
+| Delete              | Remove a contact                         |
+| List                | List all contacts                        |
+| Add to Segment      | Add a contact to a segment               |
+| List Segments       | List segments for a contact              |
+| Remove From Segment | Remove a contact from a segment          |
+| Get Topics          | Get topic subscriptions for a contact    |
+| Update Topics       | Update topic subscriptions for a contact |
 
 ### Contact Property
 
@@ -142,13 +164,15 @@ docker run -it --rm \
 
 ### Template
 
-| Operation | Description               |
-| --------- | ------------------------- |
-| Create    | Create an email template  |
-| Get       | Retrieve template details |
-| Update    | Modify a template         |
-| Delete    | Remove a template         |
-| List      | List all templates        |
+| Operation | Description                    |
+| --------- | ------------------------------ |
+| Create    | Create an email template       |
+| Get       | Retrieve template details      |
+| Update    | Modify a template              |
+| Delete    | Remove a template              |
+| List      | List all templates             |
+| Publish   | Publish a template             |
+| Duplicate | Duplicate an existing template |
 
 ### Domain
 
@@ -183,8 +207,8 @@ docker run -it --rm \
 
 The **Resend Trigger** node receives webhooks for real-time email events. Signatures are automatically verified using Svix.
 
-| Event                      | Description                  |
-| -------------------------- | ---------------------------- |
+| Event                    | Description                  |
+| ------------------------ | ---------------------------- |
 | `email.sent`             | Email sent to recipient      |
 | `email.delivered`        | Email delivered successfully |
 | `email.delivery_delayed` | Email delivery delayed       |

--- a/README.md
+++ b/README.md
@@ -28,20 +28,20 @@ A community node for [n8n](https://n8n.io) that integrates with the [Resend](htt
 
 Comprehensive coverage of the Resend API (v1.1.0). The table below shows which endpoints are currently implemented:
 
-| API Resource           | Endpoint                   | Status     | Operations                                                                                                       |
-| ---------------------- | -------------------------- | ---------- | ---------------------------------------------------------------------------------------------------------------- |
-| **Email**              | `/emails`                  | ✅ Full    | Send, Send Batch, List, Get, Update, Cancel, List Attachments, Get Attachment                                    |
-| **Receiving Emails**   | `/emails/receiving`        | ✅ Full    | List, Get, List Attachments, Get Attachment                                                                      |
-| **Domains**            | `/domains`                 | ✅ Full    | Create, List, Get, Update, Delete, Verify                                                                        |
-| **API Keys**           | `/api-keys`                | ✅ Full    | Create, List, Delete                                                                                             |
-| **Templates**          | `/templates`               | ✅ Full    | Create, List, Get, Update, Delete, Publish, Duplicate                                                            |
-| **Audiences**          | `/audiences`               | ✅ Full    | Create, List, Get, Delete                                                                                        |
-| **Contacts**           | `/audiences/{id}/contacts` | ✅ Full    | Create, List, Get, Update, Delete, Add to Segment, List Segments, Remove from Segment, Get Topics, Update Topics |
-| **Broadcasts**         | `/broadcasts`              | ✅ Full    | Create, List, Get, Update, Delete, Send                                                                          |
-| **Segments**           | `/segments`                | ⚠️ Partial | Create, List, Get, Delete (Missing: Update, Filter conditions)                                                   |
-| **Topics**             | `/topics`                  | ✅ Full    | Create, List, Get, Update, Delete                                                                                |
-| **Contact Properties** | `/contact-properties`      | ✅ Full    | Create, List, Get, Update, Delete                                                                                |
-| **Webhooks**           | `/webhooks`                | ✅ Full    | Create, List, Get, Update, Delete                                                                                |
+| API Resource           | Endpoint                   | Status  | Operations                                                                                                       |
+| ---------------------- | -------------------------- | ------- | ---------------------------------------------------------------------------------------------------------------- |
+| **Email**              | `/emails`                  | ✅ Full | Send, Send Batch, List, Get, Update, Cancel, List Attachments, Get Attachment                                    |
+| **Receiving Emails**   | `/emails/receiving`        | ✅ Full | List, Get, List Attachments, Get Attachment                                                                      |
+| **Domains**            | `/domains`                 | ✅ Full | Create, List, Get, Update, Delete, Verify                                                                        |
+| **API Keys**           | `/api-keys`                | ✅ Full | Create, List, Delete                                                                                             |
+| **Templates**          | `/templates`               | ✅ Full | Create, List, Get, Update, Delete, Publish, Duplicate                                                            |
+| **Audiences**          | `/audiences`               | ✅ Full | Create, List, Get, Delete                                                                                        |
+| **Contacts**           | `/audiences/{id}/contacts` | ✅ Full | Create, List, Get, Update, Delete, Add to Segment, List Segments, Remove from Segment, Get Topics, Update Topics |
+| **Broadcasts**         | `/broadcasts`              | ✅ Full | Create, List, Get, Update, Delete, Send                                                                          |
+| **Segments**           | `/segments`                | ✅ Full | Create, List, Get, Delete                                                                                        |
+| **Topics**             | `/topics`                  | ✅ Full | Create, List, Get, Update, Delete                                                                                |
+| **Contact Properties** | `/contact-properties`      | ✅ Full | Create, List, Get, Update, Delete                                                                                |
+| **Webhooks**           | `/webhooks`                | ✅ Full | Create, List, Get, Update, Delete                                                                                |
 
 ## Installation
 
@@ -134,12 +134,12 @@ docker run -it --rm \
 
 ### Segment
 
-| Operation | Description              |
-| --------- | ------------------------ |
-| Create    | Create a new segment     |
-| Get       | Retrieve segment details |
-| Delete    | Remove a segment         |
-| List      | List all segments        |
+| Operation | Description                                          |
+| --------- | ---------------------------------------------------- |
+| Create    | Create a new segment with optional filter conditions |
+| Get       | Retrieve segment details                             |
+| Delete    | Remove a segment                                     |
+| List      | List all segments                                    |
 
 ### Topic
 

--- a/nodes/Resend/Resend.node.ts
+++ b/nodes/Resend/Resend.node.ts
@@ -12,7 +12,10 @@ import * as topics from './actions/topic';
 import * as contacts from './actions/contact';
 import * as contactProperties from './actions/contactProperty';
 import * as webhooks from './actions/webhook';
+import * as audiences from './actions/audience';
+import * as receivingEmails from './actions/receivingEmail';
 import {
+	getAudiences,
 	getSegments,
 	getTemplateVariables,
 	getTemplates,
@@ -32,7 +35,7 @@ export class Resend implements INodeType {
 		description:
 			'Interact with Resend API for emails, templates, domains, API keys, broadcasts, segments, topics, contacts, contact properties, and webhooks',
 		subtitle:
-			'={{(() => { const resourceLabels = { apiKeys: "api key", broadcasts: "broadcast", contacts: "contact", contactProperties: "contact property", domains: "domain", email: "email", segments: "segment", templates: "template", topics: "topic", webhooks: "webhook" }; const operationLabels = { retrieve: "get", sendBatch: "send batch" }; const resource = $parameter["resource"]; const operation = $parameter["operation"]; const resourceLabel = resourceLabels[resource] ?? resource; const operationLabel = operationLabels[operation] ?? operation; return operationLabel + ": " + resourceLabel; })() }}',
+			'={{(() => { const resourceLabels = { apiKeys: "api key", audiences: "audience", broadcasts: "broadcast", contacts: "contact", contactProperties: "contact property", domains: "domain", email: "email", receivingEmails: "received email", segments: "segment", templates: "template", topics: "topic", webhooks: "webhook" }; const operationLabels = { retrieve: "get", sendBatch: "send batch", listAttachments: "list attachments", getAttachment: "get attachment", addToSegment: "add to segment", listSegments: "list segments", removeFromSegment: "remove from segment", getTopics: "get topics", updateTopics: "update topics" }; const resource = $parameter["resource"]; const operation = $parameter["operation"]; const resourceLabel = resourceLabels[resource] ?? resource; const operationLabel = operationLabels[operation] ?? operation; return operationLabel + ": " + resourceLabel; })() }}',
 		defaults: {
 			name: 'Resend',
 		},
@@ -58,6 +61,11 @@ export class Resend implements INodeType {
 						description: 'Manage API keys',
 					},
 					{
+						name: 'Audience',
+						value: 'audiences',
+						description: 'Manage audiences',
+					},
+					{
 						name: 'Broadcast',
 						value: 'broadcasts',
 						description: 'Manage email broadcasts',
@@ -81,6 +89,11 @@ export class Resend implements INodeType {
 						name: 'Email',
 						value: 'email',
 						description: 'Send and manage emails',
+					},
+					{
+						name: 'Receiving Email',
+						value: 'receivingEmails',
+						description: 'Manage received emails and attachments',
 					},
 					{
 						name: 'Segment',
@@ -116,6 +129,8 @@ export class Resend implements INodeType {
 			...contacts.descriptions,
 			...contactProperties.descriptions,
 			...webhooks.descriptions,
+			...audiences.descriptions,
+			...receivingEmails.descriptions,
 		],
 	};
 
@@ -125,6 +140,7 @@ export class Resend implements INodeType {
 			getTemplates,
 			getSegments,
 			getTopics,
+			getAudiences,
 		},
 	};
 

--- a/nodes/Resend/actions/audience/create.operation.ts
+++ b/nodes/Resend/actions/audience/create.operation.ts
@@ -1,0 +1,33 @@
+import type { INodeProperties, IExecuteFunctions, INodeExecutionData } from 'n8n-workflow';
+import { apiRequest } from '../../transport';
+
+export const description: INodeProperties[] = [
+	{
+		displayName: 'Audience Name',
+		name: 'audienceName',
+		type: 'string',
+		required: true,
+		default: '',
+		placeholder: 'Registered Users',
+		displayOptions: {
+			show: {
+				resource: ['audiences'],
+				operation: ['create'],
+			},
+		},
+		description: 'The name of the audience',
+	},
+];
+
+export async function execute(
+	this: IExecuteFunctions,
+	index: number,
+): Promise<INodeExecutionData[]> {
+	const audienceName = this.getNodeParameter('audienceName', index) as string;
+
+	const response = await apiRequest.call(this, 'POST', '/audiences', {
+		name: audienceName,
+	});
+
+	return [{ json: response, pairedItem: { item: index } }];
+}

--- a/nodes/Resend/actions/audience/delete.operation.ts
+++ b/nodes/Resend/actions/audience/delete.operation.ts
@@ -1,0 +1,34 @@
+import type { INodeProperties, IExecuteFunctions, INodeExecutionData } from 'n8n-workflow';
+import { apiRequest } from '../../transport';
+
+export const description: INodeProperties[] = [
+	{
+		displayName: 'Audience ID',
+		name: 'audienceId',
+		type: 'string',
+		required: true,
+		default: '',
+		displayOptions: {
+			show: {
+				resource: ['audiences'],
+				operation: ['delete'],
+			},
+		},
+		description: 'The ID of the audience to delete',
+	},
+];
+
+export async function execute(
+	this: IExecuteFunctions,
+	index: number,
+): Promise<INodeExecutionData[]> {
+	const audienceId = this.getNodeParameter('audienceId', index) as string;
+
+	const response = await apiRequest.call(
+		this,
+		'DELETE',
+		`/audiences/${encodeURIComponent(audienceId)}`,
+	);
+
+	return [{ json: response, pairedItem: { item: index } }];
+}

--- a/nodes/Resend/actions/audience/execute.ts
+++ b/nodes/Resend/actions/audience/execute.ts
@@ -3,10 +3,7 @@ import type { IExecuteFunctions, INodeExecutionData } from 'n8n-workflow';
 import * as create from './create.operation';
 import * as get from './get.operation';
 import * as list from './list.operation';
-import * as update from './update.operation';
 import * as del from './delete.operation';
-import * as publish from './publish.operation';
-import * as duplicate from './duplicate.operation';
 
 export async function execute(
 	this: IExecuteFunctions,
@@ -20,15 +17,9 @@ export async function execute(
 			return get.execute.call(this, index);
 		case 'list':
 			return list.execute.call(this);
-		case 'update':
-			return update.execute.call(this, index);
 		case 'delete':
 			return del.execute.call(this, index);
-		case 'publish':
-			return publish.execute.call(this, index);
-		case 'duplicate':
-			return duplicate.execute.call(this, index);
 		default:
-			throw new Error(`Unsupported operation: ${operation}`);
+			throw new Error(`Unknown operation: ${operation}`);
 	}
 }

--- a/nodes/Resend/actions/audience/get.operation.ts
+++ b/nodes/Resend/actions/audience/get.operation.ts
@@ -1,0 +1,34 @@
+import type { INodeProperties, IExecuteFunctions, INodeExecutionData } from 'n8n-workflow';
+import { apiRequest } from '../../transport';
+
+export const description: INodeProperties[] = [
+	{
+		displayName: 'Audience ID',
+		name: 'audienceId',
+		type: 'string',
+		required: true,
+		default: '',
+		displayOptions: {
+			show: {
+				resource: ['audiences'],
+				operation: ['get'],
+			},
+		},
+		description: 'The ID of the audience to retrieve',
+	},
+];
+
+export async function execute(
+	this: IExecuteFunctions,
+	index: number,
+): Promise<INodeExecutionData[]> {
+	const audienceId = this.getNodeParameter('audienceId', index) as string;
+
+	const response = await apiRequest.call(
+		this,
+		'GET',
+		`/audiences/${encodeURIComponent(audienceId)}`,
+	);
+
+	return [{ json: response, pairedItem: { item: index } }];
+}

--- a/nodes/Resend/actions/audience/index.ts
+++ b/nodes/Resend/actions/audience/index.ts
@@ -1,0 +1,54 @@
+import type { INodeProperties } from 'n8n-workflow';
+
+import * as create from './create.operation';
+import * as get from './get.operation';
+import * as list from './list.operation';
+import * as del from './delete.operation';
+
+export { create, get, list, del as delete };
+export { execute } from './execute';
+
+export const descriptions: INodeProperties[] = [
+	{
+		displayName: 'Operation',
+		name: 'operation',
+		type: 'options',
+		noDataExpression: true,
+		displayOptions: {
+			show: {
+				resource: ['audiences'],
+			},
+		},
+		options: [
+			{
+				name: 'Create',
+				value: 'create',
+				description: 'Create a new audience',
+				action: 'Create an audience',
+			},
+			{
+				name: 'Delete',
+				value: 'delete',
+				description: 'Delete an audience',
+				action: 'Delete an audience',
+			},
+			{
+				name: 'Get',
+				value: 'get',
+				description: 'Get an audience by ID',
+				action: 'Get an audience',
+			},
+			{
+				name: 'List',
+				value: 'list',
+				description: 'List all audiences',
+				action: 'List audiences',
+			},
+		],
+		default: 'list',
+	},
+	...create.description,
+	...get.description,
+	...list.description,
+	...del.description,
+];

--- a/nodes/Resend/actions/audience/list.operation.ts
+++ b/nodes/Resend/actions/audience/list.operation.ts
@@ -1,0 +1,9 @@
+import type { IExecuteFunctions, INodeExecutionData, INodeProperties } from 'n8n-workflow';
+import { requestList, createListExecutionData } from '../../transport';
+
+export const description: INodeProperties[] = [];
+
+export async function execute(this: IExecuteFunctions): Promise<INodeExecutionData[]> {
+	const items = await requestList.call(this, '/audiences');
+	return createListExecutionData.call(this, items);
+}

--- a/nodes/Resend/actions/contact/addToSegment.operation.ts
+++ b/nodes/Resend/actions/contact/addToSegment.operation.ts
@@ -1,0 +1,69 @@
+import type { INodeProperties, IExecuteFunctions, INodeExecutionData, IDataObject } from 'n8n-workflow';
+import { apiRequest } from '../../transport';
+
+export const description: INodeProperties[] = [
+	{
+		displayName: 'Audience ID',
+		name: 'audienceIdAddSegment',
+		type: 'string',
+		required: true,
+		default: '',
+		displayOptions: {
+			show: {
+				resource: ['contacts'],
+				operation: ['addToSegment'],
+			},
+		},
+		description: 'The ID of the audience the contact belongs to',
+	},
+	{
+		displayName: 'Contact ID',
+		name: 'contactIdAddSegment',
+		type: 'string',
+		required: true,
+		default: '',
+		displayOptions: {
+			show: {
+				resource: ['contacts'],
+				operation: ['addToSegment'],
+			},
+		},
+		description: 'The ID of the contact',
+	},
+	{
+		displayName: 'Segment ID',
+		name: 'segmentIdAdd',
+		type: 'string',
+		required: true,
+		default: '',
+		displayOptions: {
+			show: {
+				resource: ['contacts'],
+				operation: ['addToSegment'],
+			},
+		},
+		description: 'The ID of the segment to add the contact to',
+	},
+];
+
+export async function execute(
+	this: IExecuteFunctions,
+	index: number,
+): Promise<INodeExecutionData[]> {
+	const audienceId = this.getNodeParameter('audienceIdAddSegment', index) as string;
+	const contactId = this.getNodeParameter('contactIdAddSegment', index) as string;
+	const segmentId = this.getNodeParameter('segmentIdAdd', index) as string;
+
+	const body: IDataObject = {
+		segment_id: segmentId,
+	};
+
+	const response = await apiRequest.call(
+		this,
+		'POST',
+		`/audiences/${encodeURIComponent(audienceId)}/contacts/${encodeURIComponent(contactId)}/segments`,
+		body,
+	);
+
+	return [{ json: response, pairedItem: { item: index } }];
+}

--- a/nodes/Resend/actions/contact/execute.ts
+++ b/nodes/Resend/actions/contact/execute.ts
@@ -5,6 +5,11 @@ import * as get from './get.operation';
 import * as list from './list.operation';
 import * as update from './update.operation';
 import * as del from './delete.operation';
+import * as addToSegment from './addToSegment.operation';
+import * as listSegments from './listSegments.operation';
+import * as removeFromSegment from './removeFromSegment.operation';
+import * as getTopics from './getTopics.operation';
+import * as updateTopics from './updateTopics.operation';
 
 export async function execute(
 	this: IExecuteFunctions,
@@ -22,6 +27,16 @@ export async function execute(
 			return update.execute.call(this, index);
 		case 'delete':
 			return del.execute.call(this, index);
+		case 'addToSegment':
+			return addToSegment.execute.call(this, index);
+		case 'listSegments':
+			return listSegments.execute.call(this, index);
+		case 'removeFromSegment':
+			return removeFromSegment.execute.call(this, index);
+		case 'getTopics':
+			return getTopics.execute.call(this, index);
+		case 'updateTopics':
+			return updateTopics.execute.call(this, index);
 		default:
 			throw new Error(`Unsupported operation: ${operation}`);
 	}

--- a/nodes/Resend/actions/contact/getTopics.operation.ts
+++ b/nodes/Resend/actions/contact/getTopics.operation.ts
@@ -1,0 +1,94 @@
+import type { IExecuteFunctions, INodeExecutionData, INodeProperties, IDataObject } from 'n8n-workflow';
+import { apiRequest } from '../../transport';
+
+export const description: INodeProperties[] = [
+	{
+		displayName: 'Audience ID',
+		name: 'audienceIdGetTopics',
+		type: 'string',
+		required: true,
+		default: '',
+		displayOptions: {
+			show: {
+				resource: ['contacts'],
+				operation: ['getTopics'],
+			},
+		},
+		description: 'The ID of the audience the contact belongs to',
+	},
+	{
+		displayName: 'Contact ID',
+		name: 'contactIdGetTopics',
+		type: 'string',
+		required: true,
+		default: '',
+		displayOptions: {
+			show: {
+				resource: ['contacts'],
+				operation: ['getTopics'],
+			},
+		},
+		description: 'The ID of the contact',
+	},
+	{
+		displayName: 'Return All',
+		name: 'returnAll',
+		type: 'boolean',
+		default: false,
+		displayOptions: {
+			show: {
+				resource: ['contacts'],
+				operation: ['getTopics'],
+			},
+		},
+		description: 'Whether to return all results or only up to a given limit',
+	},
+	{
+		displayName: 'Limit',
+		name: 'limit',
+		type: 'number',
+		default: 50,
+		typeOptions: {
+			minValue: 1,
+		},
+		displayOptions: {
+			show: {
+				resource: ['contacts'],
+				operation: ['getTopics'],
+				returnAll: [false],
+			},
+		},
+		description: 'Max number of results to return',
+	},
+];
+
+export async function execute(
+	this: IExecuteFunctions,
+	index: number,
+): Promise<INodeExecutionData[]> {
+	const audienceId = this.getNodeParameter('audienceIdGetTopics', index) as string;
+	const contactId = this.getNodeParameter('contactIdGetTopics', index) as string;
+	const returnAll = this.getNodeParameter('returnAll', index, false) as boolean;
+	const limit = this.getNodeParameter('limit', index, 50) as number;
+
+	const qs: IDataObject = {};
+	if (!returnAll) {
+		qs.limit = limit;
+	}
+
+	const response = await apiRequest.call(
+		this,
+		'GET',
+		`/audiences/${encodeURIComponent(audienceId)}/contacts/${encodeURIComponent(contactId)}/topics`,
+		undefined,
+		qs,
+	);
+
+	const items = (response as { data?: IDataObject[] }).data ?? [];
+	const inputData = this.getInputData();
+
+	return items.map((item, i) => ({
+		json: item,
+		pairedItem: { item: i < inputData.length ? i : 0 },
+	}));
+}

--- a/nodes/Resend/actions/contact/index.ts
+++ b/nodes/Resend/actions/contact/index.ts
@@ -4,6 +4,11 @@ import * as get from './get.operation';
 import * as list from './list.operation';
 import * as update from './update.operation';
 import * as del from './delete.operation';
+import * as addToSegment from './addToSegment.operation';
+import * as listSegments from './listSegments.operation';
+import * as removeFromSegment from './removeFromSegment.operation';
+import * as getTopics from './getTopics.operation';
+import * as updateTopics from './updateTopics.operation';
 
 export const operations: INodeProperties[] = [
 	{
@@ -17,6 +22,12 @@ export const operations: INodeProperties[] = [
 			},
 		},
 		options: [
+			{
+				name: 'Add to Segment',
+				value: 'addToSegment',
+				description: 'Add a contact to a segment',
+				action: 'Add contact to segment',
+			},
 			{
 				name: 'Create',
 				value: 'create',
@@ -36,16 +47,40 @@ export const operations: INodeProperties[] = [
 				action: 'Get a contact',
 			},
 			{
+				name: 'Get Topics',
+				value: 'getTopics',
+				description: 'Get topics for a contact',
+				action: 'Get contact topics',
+			},
+			{
 				name: 'List',
 				value: 'list',
 				description: 'List contacts',
 				action: 'List contacts',
 			},
 			{
+				name: 'List Segments',
+				value: 'listSegments',
+				description: 'List segments for a contact',
+				action: 'List contact segments',
+			},
+			{
+				name: 'Remove From Segment',
+				value: 'removeFromSegment',
+				description: 'Remove a contact from a segment',
+				action: 'Remove contact from segment',
+			},
+			{
 				name: 'Update',
 				value: 'update',
 				description: 'Update a contact',
 				action: 'Update a contact',
+			},
+			{
+				name: 'Update Topics',
+				value: 'updateTopics',
+				description: 'Update topic subscriptions for a contact',
+				action: 'Update contact topics',
 			},
 		],
 		default: 'list',
@@ -59,7 +94,12 @@ export const descriptions: INodeProperties[] = [
 	...list.description,
 	...update.description,
 	...del.description,
+	...addToSegment.description,
+	...listSegments.description,
+	...removeFromSegment.description,
+	...getTopics.description,
+	...updateTopics.description,
 ];
 
-export { create, get, list, update, del as delete };
+export { create, get, list, update, del as delete, addToSegment, listSegments, removeFromSegment, getTopics, updateTopics };
 export { execute } from './execute';

--- a/nodes/Resend/actions/contact/listSegments.operation.ts
+++ b/nodes/Resend/actions/contact/listSegments.operation.ts
@@ -1,0 +1,94 @@
+import type { IExecuteFunctions, INodeExecutionData, INodeProperties, IDataObject } from 'n8n-workflow';
+import { apiRequest } from '../../transport';
+
+export const description: INodeProperties[] = [
+	{
+		displayName: 'Audience ID',
+		name: 'audienceIdListSegments',
+		type: 'string',
+		required: true,
+		default: '',
+		displayOptions: {
+			show: {
+				resource: ['contacts'],
+				operation: ['listSegments'],
+			},
+		},
+		description: 'The ID of the audience the contact belongs to',
+	},
+	{
+		displayName: 'Contact ID',
+		name: 'contactIdListSegments',
+		type: 'string',
+		required: true,
+		default: '',
+		displayOptions: {
+			show: {
+				resource: ['contacts'],
+				operation: ['listSegments'],
+			},
+		},
+		description: 'The ID of the contact',
+	},
+	{
+		displayName: 'Return All',
+		name: 'returnAll',
+		type: 'boolean',
+		default: false,
+		displayOptions: {
+			show: {
+				resource: ['contacts'],
+				operation: ['listSegments'],
+			},
+		},
+		description: 'Whether to return all results or only up to a given limit',
+	},
+	{
+		displayName: 'Limit',
+		name: 'limit',
+		type: 'number',
+		default: 50,
+		typeOptions: {
+			minValue: 1,
+		},
+		displayOptions: {
+			show: {
+				resource: ['contacts'],
+				operation: ['listSegments'],
+				returnAll: [false],
+			},
+		},
+		description: 'Max number of results to return',
+	},
+];
+
+export async function execute(
+	this: IExecuteFunctions,
+	index: number,
+): Promise<INodeExecutionData[]> {
+	const audienceId = this.getNodeParameter('audienceIdListSegments', index) as string;
+	const contactId = this.getNodeParameter('contactIdListSegments', index) as string;
+	const returnAll = this.getNodeParameter('returnAll', index, false) as boolean;
+	const limit = this.getNodeParameter('limit', index, 50) as number;
+
+	const qs: IDataObject = {};
+	if (!returnAll) {
+		qs.limit = limit;
+	}
+
+	const response = await apiRequest.call(
+		this,
+		'GET',
+		`/audiences/${encodeURIComponent(audienceId)}/contacts/${encodeURIComponent(contactId)}/segments`,
+		undefined,
+		qs,
+	);
+
+	const items = (response as { data?: IDataObject[] }).data ?? [];
+	const inputData = this.getInputData();
+
+	return items.map((item, i) => ({
+		json: item,
+		pairedItem: { item: i < inputData.length ? i : 0 },
+	}));
+}

--- a/nodes/Resend/actions/contact/removeFromSegment.operation.ts
+++ b/nodes/Resend/actions/contact/removeFromSegment.operation.ts
@@ -1,0 +1,64 @@
+import type { INodeProperties, IExecuteFunctions, INodeExecutionData } from 'n8n-workflow';
+import { apiRequest } from '../../transport';
+
+export const description: INodeProperties[] = [
+	{
+		displayName: 'Audience ID',
+		name: 'audienceIdRemoveSegment',
+		type: 'string',
+		required: true,
+		default: '',
+		displayOptions: {
+			show: {
+				resource: ['contacts'],
+				operation: ['removeFromSegment'],
+			},
+		},
+		description: 'The ID of the audience the contact belongs to',
+	},
+	{
+		displayName: 'Contact ID',
+		name: 'contactIdRemoveSegment',
+		type: 'string',
+		required: true,
+		default: '',
+		displayOptions: {
+			show: {
+				resource: ['contacts'],
+				operation: ['removeFromSegment'],
+			},
+		},
+		description: 'The ID of the contact',
+	},
+	{
+		displayName: 'Segment ID',
+		name: 'segmentIdRemove',
+		type: 'string',
+		required: true,
+		default: '',
+		displayOptions: {
+			show: {
+				resource: ['contacts'],
+				operation: ['removeFromSegment'],
+			},
+		},
+		description: 'The ID of the segment to remove the contact from',
+	},
+];
+
+export async function execute(
+	this: IExecuteFunctions,
+	index: number,
+): Promise<INodeExecutionData[]> {
+	const audienceId = this.getNodeParameter('audienceIdRemoveSegment', index) as string;
+	const contactId = this.getNodeParameter('contactIdRemoveSegment', index) as string;
+	const segmentId = this.getNodeParameter('segmentIdRemove', index) as string;
+
+	const response = await apiRequest.call(
+		this,
+		'DELETE',
+		`/audiences/${encodeURIComponent(audienceId)}/contacts/${encodeURIComponent(contactId)}/segments/${encodeURIComponent(segmentId)}`,
+	);
+
+	return [{ json: response, pairedItem: { item: index } }];
+}

--- a/nodes/Resend/actions/contact/updateTopics.operation.ts
+++ b/nodes/Resend/actions/contact/updateTopics.operation.ts
@@ -1,0 +1,106 @@
+import type { INodeProperties, IExecuteFunctions, INodeExecutionData, IDataObject } from 'n8n-workflow';
+import { apiRequest } from '../../transport';
+
+export const description: INodeProperties[] = [
+	{
+		displayName: 'Audience ID',
+		name: 'audienceIdUpdateTopics',
+		type: 'string',
+		required: true,
+		default: '',
+		displayOptions: {
+			show: {
+				resource: ['contacts'],
+				operation: ['updateTopics'],
+			},
+		},
+		description: 'The ID of the audience the contact belongs to',
+	},
+	{
+		displayName: 'Contact ID',
+		name: 'contactIdUpdateTopics',
+		type: 'string',
+		required: true,
+		default: '',
+		displayOptions: {
+			show: {
+				resource: ['contacts'],
+				operation: ['updateTopics'],
+			},
+		},
+		description: 'The ID of the contact',
+	},
+	{
+		displayName: 'Topics',
+		name: 'topicsToUpdate',
+		type: 'fixedCollection',
+		required: true,
+		default: { topics: [] },
+		typeOptions: {
+			multipleValues: true,
+		},
+		displayOptions: {
+			show: {
+				resource: ['contacts'],
+				operation: ['updateTopics'],
+			},
+		},
+		options: [
+			{
+				name: 'topics',
+				displayName: 'Topic',
+				values: [
+					{
+						displayName: 'Topic ID',
+						name: 'id',
+						type: 'string',
+						required: true,
+						default: '',
+						description: 'The ID of the topic',
+					},
+					{
+						displayName: 'Subscribed',
+						name: 'subscribed',
+						type: 'boolean',
+						required: true,
+						default: true,
+						description: 'Whether the contact should be subscribed to this topic',
+					},
+				],
+			},
+		],
+		description: 'Topics to update for the contact',
+	},
+];
+
+interface TopicItem {
+	id: string;
+	subscribed: boolean;
+}
+
+export async function execute(
+	this: IExecuteFunctions,
+	index: number,
+): Promise<INodeExecutionData[]> {
+	const audienceId = this.getNodeParameter('audienceIdUpdateTopics', index) as string;
+	const contactId = this.getNodeParameter('contactIdUpdateTopics', index) as string;
+	const topicsInput = this.getNodeParameter('topicsToUpdate', index, { topics: [] }) as {
+		topics: TopicItem[];
+	};
+
+	const body: IDataObject = {
+		topics: topicsInput.topics.map((t) => ({
+			id: t.id,
+			subscribed: t.subscribed,
+		})),
+	};
+
+	const response = await apiRequest.call(
+		this,
+		'PATCH',
+		`/audiences/${encodeURIComponent(audienceId)}/contacts/${encodeURIComponent(contactId)}/topics`,
+		body,
+	);
+
+	return [{ json: response, pairedItem: { item: index } }];
+}

--- a/nodes/Resend/actions/email/getAttachment.operation.ts
+++ b/nodes/Resend/actions/email/getAttachment.operation.ts
@@ -1,0 +1,49 @@
+import type { INodeProperties, IExecuteFunctions, INodeExecutionData } from 'n8n-workflow';
+import { apiRequest } from '../../transport';
+
+export const description: INodeProperties[] = [
+	{
+		displayName: 'Email ID',
+		name: 'emailIdForAttachment',
+		type: 'string',
+		required: true,
+		default: '',
+		displayOptions: {
+			show: {
+				resource: ['email'],
+				operation: ['getAttachment'],
+			},
+		},
+		description: 'The ID of the sent email',
+	},
+	{
+		displayName: 'Attachment ID',
+		name: 'attachmentId',
+		type: 'string',
+		required: true,
+		default: '',
+		displayOptions: {
+			show: {
+				resource: ['email'],
+				operation: ['getAttachment'],
+			},
+		},
+		description: 'The ID of the attachment to retrieve',
+	},
+];
+
+export async function execute(
+	this: IExecuteFunctions,
+	index: number,
+): Promise<INodeExecutionData[]> {
+	const emailId = this.getNodeParameter('emailIdForAttachment', index) as string;
+	const attachmentId = this.getNodeParameter('attachmentId', index) as string;
+
+	const response = await apiRequest.call(
+		this,
+		'GET',
+		`/emails/${encodeURIComponent(emailId)}/attachments/${encodeURIComponent(attachmentId)}`,
+	);
+
+	return [{ json: response, pairedItem: { item: index } }];
+}

--- a/nodes/Resend/actions/email/index.ts
+++ b/nodes/Resend/actions/email/index.ts
@@ -5,6 +5,8 @@ import * as list from './list.operation';
 import * as retrieve from './retrieve.operation';
 import * as update from './update.operation';
 import * as cancel from './cancel.operation';
+import * as listAttachments from './listAttachments.operation';
+import * as getAttachment from './getAttachment.operation';
 
 export const operations: INodeProperties[] = [
 	{
@@ -25,10 +27,22 @@ export const operations: INodeProperties[] = [
 				action: 'Cancel an email',
 			},
 			{
+				name: 'Get Attachment',
+				value: 'getAttachment',
+				description: 'Get an attachment from a sent email',
+				action: 'Get an attachment',
+			},
+			{
 				name: 'List',
 				value: 'list',
 				description: 'List sent emails',
 				action: 'List emails',
+			},
+			{
+				name: 'List Attachments',
+				value: 'listAttachments',
+				description: 'List attachments for a sent email',
+				action: 'List attachments',
 			},
 			{
 				name: 'Retrieve',
@@ -67,7 +81,9 @@ export const descriptions: INodeProperties[] = [
 	...retrieve.description,
 	...update.description,
 	...cancel.description,
+	...listAttachments.description,
+	...getAttachment.description,
 ];
 
 export { execute } from './execute';
-export { send, sendBatch, list, retrieve, update, cancel };
+export { send, sendBatch, list, retrieve, update, cancel, listAttachments, getAttachment };

--- a/nodes/Resend/actions/email/listAttachments.operation.ts
+++ b/nodes/Resend/actions/email/listAttachments.operation.ts
@@ -1,0 +1,79 @@
+import type { IExecuteFunctions, INodeExecutionData, INodeProperties, IDataObject } from 'n8n-workflow';
+import { apiRequest } from '../../transport';
+
+export const description: INodeProperties[] = [
+	{
+		displayName: 'Email ID',
+		name: 'emailIdForAttachments',
+		type: 'string',
+		required: true,
+		default: '',
+		displayOptions: {
+			show: {
+				resource: ['email'],
+				operation: ['listAttachments'],
+			},
+		},
+		description: 'The ID of the sent email',
+	},
+	{
+		displayName: 'Return All',
+		name: 'returnAll',
+		type: 'boolean',
+		default: false,
+		displayOptions: {
+			show: {
+				resource: ['email'],
+				operation: ['listAttachments'],
+			},
+		},
+		description: 'Whether to return all results or only up to a given limit',
+	},
+	{
+		displayName: 'Limit',
+		name: 'limit',
+		type: 'number',
+		default: 50,
+		typeOptions: {
+			minValue: 1,
+		},
+		displayOptions: {
+			show: {
+				resource: ['email'],
+				operation: ['listAttachments'],
+				returnAll: [false],
+			},
+		},
+		description: 'Max number of results to return',
+	},
+];
+
+export async function execute(
+	this: IExecuteFunctions,
+	index: number,
+): Promise<INodeExecutionData[]> {
+	const emailId = this.getNodeParameter('emailIdForAttachments', index) as string;
+	const returnAll = this.getNodeParameter('returnAll', index, false) as boolean;
+	const limit = this.getNodeParameter('limit', index, 50) as number;
+
+	const qs: IDataObject = {};
+	if (!returnAll) {
+		qs.limit = limit;
+	}
+
+	const response = await apiRequest.call(
+		this,
+		'GET',
+		`/emails/${encodeURIComponent(emailId)}/attachments`,
+		undefined,
+		qs,
+	);
+
+	const items = (response as { data?: IDataObject[] }).data ?? [];
+	const inputData = this.getInputData();
+
+	return items.map((item, i) => ({
+		json: item,
+		pairedItem: { item: i < inputData.length ? i : 0 },
+	}));
+}

--- a/nodes/Resend/actions/receivingEmail/execute.ts
+++ b/nodes/Resend/actions/receivingEmail/execute.ts
@@ -1,11 +1,7 @@
 import type { IExecuteFunctions, INodeExecutionData } from 'n8n-workflow';
 
-import * as send from './send.operation';
-import * as sendBatch from './sendBatch.operation';
+import * as get from './get.operation';
 import * as list from './list.operation';
-import * as retrieve from './retrieve.operation';
-import * as update from './update.operation';
-import * as cancel from './cancel.operation';
 import * as listAttachments from './listAttachments.operation';
 import * as getAttachment from './getAttachment.operation';
 
@@ -15,23 +11,15 @@ export async function execute(
 	operation: string,
 ): Promise<INodeExecutionData[]> {
 	switch (operation) {
-		case 'send':
-			return send.execute.call(this, index);
-		case 'sendBatch':
-			return sendBatch.execute.call(this, index);
 		case 'list':
 			return list.execute.call(this);
-		case 'retrieve':
-			return retrieve.execute.call(this, index);
-		case 'update':
-			return update.execute.call(this, index);
-		case 'cancel':
-			return cancel.execute.call(this, index);
+		case 'get':
+			return get.execute.call(this, index);
 		case 'listAttachments':
 			return listAttachments.execute.call(this, index);
 		case 'getAttachment':
 			return getAttachment.execute.call(this, index);
 		default:
-			throw new Error(`Unsupported operation: ${operation}`);
+			throw new Error(`Unknown operation: ${operation}`);
 	}
 }

--- a/nodes/Resend/actions/receivingEmail/get.operation.ts
+++ b/nodes/Resend/actions/receivingEmail/get.operation.ts
@@ -1,0 +1,34 @@
+import type { INodeProperties, IExecuteFunctions, INodeExecutionData } from 'n8n-workflow';
+import { apiRequest } from '../../transport';
+
+export const description: INodeProperties[] = [
+	{
+		displayName: 'Email ID',
+		name: 'receivedEmailId',
+		type: 'string',
+		required: true,
+		default: '',
+		displayOptions: {
+			show: {
+				resource: ['receivingEmails'],
+				operation: ['get'],
+			},
+		},
+		description: 'The ID of the received email to retrieve',
+	},
+];
+
+export async function execute(
+	this: IExecuteFunctions,
+	index: number,
+): Promise<INodeExecutionData[]> {
+	const emailId = this.getNodeParameter('receivedEmailId', index) as string;
+
+	const response = await apiRequest.call(
+		this,
+		'GET',
+		`/emails/receiving/${encodeURIComponent(emailId)}`,
+	);
+
+	return [{ json: response, pairedItem: { item: index } }];
+}

--- a/nodes/Resend/actions/receivingEmail/getAttachment.operation.ts
+++ b/nodes/Resend/actions/receivingEmail/getAttachment.operation.ts
@@ -1,0 +1,49 @@
+import type { INodeProperties, IExecuteFunctions, INodeExecutionData } from 'n8n-workflow';
+import { apiRequest } from '../../transport';
+
+export const description: INodeProperties[] = [
+	{
+		displayName: 'Email ID',
+		name: 'receivedEmailIdForAttachment',
+		type: 'string',
+		required: true,
+		default: '',
+		displayOptions: {
+			show: {
+				resource: ['receivingEmails'],
+				operation: ['getAttachment'],
+			},
+		},
+		description: 'The ID of the received email',
+	},
+	{
+		displayName: 'Attachment ID',
+		name: 'receivedAttachmentId',
+		type: 'string',
+		required: true,
+		default: '',
+		displayOptions: {
+			show: {
+				resource: ['receivingEmails'],
+				operation: ['getAttachment'],
+			},
+		},
+		description: 'The ID of the attachment to retrieve',
+	},
+];
+
+export async function execute(
+	this: IExecuteFunctions,
+	index: number,
+): Promise<INodeExecutionData[]> {
+	const emailId = this.getNodeParameter('receivedEmailIdForAttachment', index) as string;
+	const attachmentId = this.getNodeParameter('receivedAttachmentId', index) as string;
+
+	const response = await apiRequest.call(
+		this,
+		'GET',
+		`/emails/receiving/${encodeURIComponent(emailId)}/attachments/${encodeURIComponent(attachmentId)}`,
+	);
+
+	return [{ json: response, pairedItem: { item: index } }];
+}

--- a/nodes/Resend/actions/receivingEmail/index.ts
+++ b/nodes/Resend/actions/receivingEmail/index.ts
@@ -1,0 +1,54 @@
+import type { INodeProperties } from 'n8n-workflow';
+
+import * as get from './get.operation';
+import * as list from './list.operation';
+import * as listAttachments from './listAttachments.operation';
+import * as getAttachment from './getAttachment.operation';
+
+export { get, list, listAttachments, getAttachment };
+export { execute } from './execute';
+
+export const descriptions: INodeProperties[] = [
+	{
+		displayName: 'Operation',
+		name: 'operation',
+		type: 'options',
+		noDataExpression: true,
+		displayOptions: {
+			show: {
+				resource: ['receivingEmails'],
+			},
+		},
+		options: [
+			{
+				name: 'Get',
+				value: 'get',
+				description: 'Get a received email by ID',
+				action: 'Get a received email',
+			},
+			{
+				name: 'Get Attachment',
+				value: 'getAttachment',
+				description: 'Get an attachment from a received email',
+				action: 'Get an attachment from received email',
+			},
+			{
+				name: 'List',
+				value: 'list',
+				description: 'List all received emails',
+				action: 'List received emails',
+			},
+			{
+				name: 'List Attachments',
+				value: 'listAttachments',
+				description: 'List attachments for a received email',
+				action: 'List attachments for received email',
+			},
+		],
+		default: 'list',
+	},
+	...list.description,
+	...get.description,
+	...listAttachments.description,
+	...getAttachment.description,
+];

--- a/nodes/Resend/actions/receivingEmail/list.operation.ts
+++ b/nodes/Resend/actions/receivingEmail/list.operation.ts
@@ -1,0 +1,9 @@
+import type { IExecuteFunctions, INodeExecutionData, INodeProperties } from 'n8n-workflow';
+import { requestList, createListExecutionData } from '../../transport';
+
+export const description: INodeProperties[] = [];
+
+export async function execute(this: IExecuteFunctions): Promise<INodeExecutionData[]> {
+	const items = await requestList.call(this, '/emails/receiving');
+	return createListExecutionData.call(this, items);
+}

--- a/nodes/Resend/actions/receivingEmail/listAttachments.operation.ts
+++ b/nodes/Resend/actions/receivingEmail/listAttachments.operation.ts
@@ -1,0 +1,79 @@
+import type { IExecuteFunctions, INodeExecutionData, INodeProperties, IDataObject } from 'n8n-workflow';
+import { apiRequest } from '../../transport';
+
+export const description: INodeProperties[] = [
+	{
+		displayName: 'Email ID',
+		name: 'receivedEmailIdForAttachments',
+		type: 'string',
+		required: true,
+		default: '',
+		displayOptions: {
+			show: {
+				resource: ['receivingEmails'],
+				operation: ['listAttachments'],
+			},
+		},
+		description: 'The ID of the received email',
+	},
+	{
+		displayName: 'Return All',
+		name: 'returnAll',
+		type: 'boolean',
+		default: false,
+		displayOptions: {
+			show: {
+				resource: ['receivingEmails'],
+				operation: ['listAttachments'],
+			},
+		},
+		description: 'Whether to return all results or only up to a given limit',
+	},
+	{
+		displayName: 'Limit',
+		name: 'limit',
+		type: 'number',
+		default: 50,
+		typeOptions: {
+			minValue: 1,
+		},
+		displayOptions: {
+			show: {
+				resource: ['receivingEmails'],
+				operation: ['listAttachments'],
+				returnAll: [false],
+			},
+		},
+		description: 'Max number of results to return',
+	},
+];
+
+export async function execute(
+	this: IExecuteFunctions,
+	index: number,
+): Promise<INodeExecutionData[]> {
+	const emailId = this.getNodeParameter('receivedEmailIdForAttachments', index) as string;
+	const returnAll = this.getNodeParameter('returnAll', index, false) as boolean;
+	const limit = this.getNodeParameter('limit', index, 50) as number;
+
+	const qs: IDataObject = {};
+	if (!returnAll) {
+		qs.limit = limit;
+	}
+
+	const response = await apiRequest.call(
+		this,
+		'GET',
+		`/emails/receiving/${encodeURIComponent(emailId)}/attachments`,
+		undefined,
+		qs,
+	);
+
+	const items = (response as { data?: IDataObject[] }).data ?? [];
+	const inputData = this.getInputData();
+
+	return items.map((item, i) => ({
+		json: item,
+		pairedItem: { item: i < inputData.length ? i : 0 },
+	}));
+}

--- a/nodes/Resend/actions/router.ts
+++ b/nodes/Resend/actions/router.ts
@@ -11,6 +11,8 @@ import * as topics from './topic';
 import * as contacts from './contact';
 import * as contactProperties from './contactProperty';
 import * as webhooks from './webhook';
+import * as audiences from './audience';
+import * as receivingEmails from './receivingEmail';
 
 export async function router(this: IExecuteFunctions): Promise<INodeExecutionData[][]> {
 	const items = this.getInputData();
@@ -52,6 +54,12 @@ export async function router(this: IExecuteFunctions): Promise<INodeExecutionDat
 					break;
 				case 'webhooks':
 					executionData = await webhooks.execute.call(this, i, operation);
+					break;
+				case 'audiences':
+					executionData = await audiences.execute.call(this, i, operation);
+					break;
+				case 'receivingEmails':
+					executionData = await receivingEmails.execute.call(this, i, operation);
 					break;
 				default:
 					throw new NodeOperationError(

--- a/nodes/Resend/actions/segment/create.operation.ts
+++ b/nodes/Resend/actions/segment/create.operation.ts
@@ -1,7 +1,26 @@
-import type { INodeProperties, IExecuteFunctions, INodeExecutionData } from 'n8n-workflow';
+import type {
+	INodeProperties,
+	IExecuteFunctions,
+	INodeExecutionData,
+	IDataObject,
+} from 'n8n-workflow';
 import { apiRequest } from '../../transport';
 
 export const description: INodeProperties[] = [
+	{
+		displayName: 'Audience ID',
+		name: 'audienceId',
+		type: 'string',
+		required: true,
+		default: '',
+		displayOptions: {
+			show: {
+				resource: ['segments'],
+				operation: ['create'],
+			},
+		},
+		description: 'The ID of the audience this segment belongs to',
+	},
 	{
 		displayName: 'Segment Name',
 		name: 'segmentName',
@@ -17,17 +36,43 @@ export const description: INodeProperties[] = [
 		},
 		description: 'The name of the segment',
 	},
+	{
+		displayName: 'Filter (JSON)',
+		name: 'segmentFilter',
+		type: 'json',
+		default: '',
+		displayOptions: {
+			show: {
+				resource: ['segments'],
+				operation: ['create'],
+			},
+		},
+		description: 'Filter conditions for the segment as JSON object',
+	},
 ];
 
 export async function execute(
 	this: IExecuteFunctions,
 	index: number,
 ): Promise<INodeExecutionData[]> {
+	const audienceId = this.getNodeParameter('audienceId', index) as string;
 	const segmentName = this.getNodeParameter('segmentName', index) as string;
+	const filterInput = this.getNodeParameter('segmentFilter', index, '') as string | IDataObject;
 
-	const response = await apiRequest.call(this, 'POST', '/segments', {
+	const body: IDataObject = {
 		name: segmentName,
-	});
+		audience_id: audienceId,
+	};
+
+	if (filterInput) {
+		if (typeof filterInput === 'string' && filterInput.trim()) {
+			body.filter = JSON.parse(filterInput);
+		} else if (typeof filterInput === 'object') {
+			body.filter = filterInput;
+		}
+	}
+
+	const response = await apiRequest.call(this, 'POST', '/segments', body);
 
 	return [{ json: response, pairedItem: { item: index } }];
 }

--- a/nodes/Resend/actions/template/duplicate.operation.ts
+++ b/nodes/Resend/actions/template/duplicate.operation.ts
@@ -1,0 +1,34 @@
+import type { INodeProperties, IExecuteFunctions, INodeExecutionData } from 'n8n-workflow';
+import { apiRequest } from '../../transport';
+
+export const description: INodeProperties[] = [
+	{
+		displayName: 'Template ID',
+		name: 'templateIdDuplicate',
+		type: 'string',
+		required: true,
+		default: '',
+		displayOptions: {
+			show: {
+				resource: ['templates'],
+				operation: ['duplicate'],
+			},
+		},
+		description: 'The ID or alias of the template to duplicate',
+	},
+];
+
+export async function execute(
+	this: IExecuteFunctions,
+	index: number,
+): Promise<INodeExecutionData[]> {
+	const templateId = this.getNodeParameter('templateIdDuplicate', index) as string;
+
+	const response = await apiRequest.call(
+		this,
+		'POST',
+		`/templates/${encodeURIComponent(templateId)}/duplicate`,
+	);
+
+	return [{ json: response, pairedItem: { item: index } }];
+}

--- a/nodes/Resend/actions/template/index.ts
+++ b/nodes/Resend/actions/template/index.ts
@@ -4,6 +4,8 @@ import * as get from './get.operation';
 import * as list from './list.operation';
 import * as update from './update.operation';
 import * as del from './delete.operation';
+import * as publish from './publish.operation';
+import * as duplicate from './duplicate.operation';
 
 export const operations: INodeProperties[] = [
 	{
@@ -30,6 +32,12 @@ export const operations: INodeProperties[] = [
 				action: 'Delete a template',
 			},
 			{
+				name: 'Duplicate',
+				value: 'duplicate',
+				description: 'Duplicate an existing template',
+				action: 'Duplicate a template',
+			},
+			{
 				name: 'Get',
 				value: 'get',
 				description: 'Get a template by ID',
@@ -40,6 +48,12 @@ export const operations: INodeProperties[] = [
 				value: 'list',
 				description: 'List all templates',
 				action: 'List templates',
+			},
+			{
+				name: 'Publish',
+				value: 'publish',
+				description: 'Publish a template',
+				action: 'Publish a template',
 			},
 			{
 				name: 'Update',
@@ -59,7 +73,9 @@ export const descriptions: INodeProperties[] = [
 	...list.description,
 	...update.description,
 	...del.description,
+	...publish.description,
+	...duplicate.description,
 ];
 
-export { create, get, list, update, del as delete };
+export { create, get, list, update, del as delete, publish, duplicate };
 export { execute } from './execute';

--- a/nodes/Resend/actions/template/publish.operation.ts
+++ b/nodes/Resend/actions/template/publish.operation.ts
@@ -1,0 +1,34 @@
+import type { INodeProperties, IExecuteFunctions, INodeExecutionData } from 'n8n-workflow';
+import { apiRequest } from '../../transport';
+
+export const description: INodeProperties[] = [
+	{
+		displayName: 'Template ID',
+		name: 'templateIdPublish',
+		type: 'string',
+		required: true,
+		default: '',
+		displayOptions: {
+			show: {
+				resource: ['templates'],
+				operation: ['publish'],
+			},
+		},
+		description: 'The ID or alias of the template to publish',
+	},
+];
+
+export async function execute(
+	this: IExecuteFunctions,
+	index: number,
+): Promise<INodeExecutionData[]> {
+	const templateId = this.getNodeParameter('templateIdPublish', index) as string;
+
+	const response = await apiRequest.call(
+		this,
+		'POST',
+		`/templates/${encodeURIComponent(templateId)}/publish`,
+	);
+
+	return [{ json: response, pairedItem: { item: index } }];
+}

--- a/nodes/Resend/methods/index.ts
+++ b/nodes/Resend/methods/index.ts
@@ -111,3 +111,7 @@ export async function getSegments(this: ILoadOptionsFunctions): Promise<INodePro
 export async function getTopics(this: ILoadOptionsFunctions): Promise<INodePropertyOptions[]> {
 	return loadDropdownOptions(this, '/topics');
 }
+
+export async function getAudiences(this: ILoadOptionsFunctions): Promise<INodePropertyOptions[]> {
+	return loadDropdownOptions(this, '/audiences');
+}

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "n8n-nodes-resend",
   "version": "2.0.1",
-  "description": "Complete Resend integration for n8n with full API coverage: Email, Broadcasts, Templates, Domains, Contacts, Segments, Topics, Webhooks, and more",
+  "description": "Resend integration for n8n with full API coverage: Email, Broadcasts, Templates, Domains, Contacts, Segments, Topics, Webhooks, and more",
   "keywords": [
     "n8n-community-node-package",
     "resend",


### PR DESCRIPTION
Add new operations and wire them into the Resend node to expand
functionality for audiences, receiving email attachments, and contact
segment/topic management.

- Add create.operation for audiences to POST /audiences.
- Add listAttachments.operation and getAttachment.operation to fetch
  attachments for received emails (list and single attachment).
- Add contact segment/topic operations: addToSegment, listSegments,
  removeFromSegment, getTopics, updateTopics and import them in the
  contact execute dispatcher.
- Wire new contact operations into nodes/Resend/actions/contact/execute.ts
  to handle new operations and route execution accordingly.

These changes enable users to manage audiences, retrieve email
attachments, and manipulate contact segments and topics from the node.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds full support for audiences, receiving emails and attachments, contact segment/topic management, and template publish/duplicate in the Resend node. Also adds sent email attachment APIs and segment create with audience/filter.

- **New Features**
  - Audiences: create, get, list, delete
  - Receiving emails: list, get, list/get attachments
  - Sent email attachments: list, get
  - Contacts: add/list/remove segments; get/update topics
  - Templates: publish, duplicate
  - Segments: create now supports audience and JSON filter

- **Refactors**
  - Wired new operations into router and execute handlers; updated node labels/subtitle
  - Added load options: getAudiences
  - Updated README to reflect full coverage and new operations
  - No breaking changes

<sup>Written for commit fd4161f6b6cd0e71a4a52acdcc4a28f7f8b74f5f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

