### PR TITLE
feat: add Resend contact & audience management examples

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,233 @@
+# Resend Node Example Workflows
+
+This folder contains example n8n workflows demonstrating the capabilities of the Resend node. These examples show real-world use cases including email automation, contact management, trigger-based workflows, and human-in-the-loop approval processes.
+
+## How to Import Workflows
+
+### Method 1: Import from File (Recommended)
+
+1. Open your n8n instance
+2. Click the **+** button or go to **Workflows** menu
+3. Click **Create new workflow** (or use an existing one)
+4. Click the **three dots menu** (⋮) in the top-right corner
+5. Select **Import from File...**
+6. Choose the `.json` file you want to import
+7. The workflow will be loaded into the editor
+
+### Method 2: Copy and Paste
+
+1. Open the `.json` file in a text editor
+2. Select and copy the entire JSON content (Ctrl+C / Cmd+C)
+3. In n8n, create a new workflow or open an existing one
+4. Paste the content (Ctrl+V / Cmd+V) directly into the workflow editor canvas
+5. The nodes will appear on the canvas
+
+### Method 3: Import from URL
+
+If you're hosting these files online:
+
+1. Click the **three dots menu** (⋮) in the top-right corner
+2. Select **Import from URL...**
+3. Paste the raw URL to the JSON file
+4. Click **Import**
+
+## After Importing
+
+After importing a workflow, you'll need to:
+
+1. **Configure Credentials**: Click on each Resend node and select or create your Resend API credentials
+2. **Update Email Addresses**: Replace placeholder email addresses (like `your@email.com`) with real addresses
+3. **Adjust Webhook URLs**: For trigger workflows, copy the webhook URL and configure it in your Resend dashboard
+4. **Test the Workflow**: Use "Execute Workflow" to test before activating
+
+---
+
+## Example Workflows
+
+### 1. Trigger: Email Event Tracking (`trigger-email-events.json`)
+
+**Description**: Monitors email delivery events (sent, delivered, opened, clicked, bounced) and logs them to a Google Sheet for analytics and reporting.
+
+**Use Case**: Track email engagement metrics, identify delivery issues, build marketing analytics dashboards.
+
+**Nodes Used**:
+
+- Resend Trigger (monitors email events)
+- Switch (routes events by type)
+- Google Sheets (logs events)
+
+**Key Features**:
+
+- Secure webhook signature verification
+- Filters for specific event types
+- Structured data logging
+
+---
+
+### 2. Trigger: Contact Sync on Events (`trigger-contact-sync.json`)
+
+**Description**: Automatically syncs contact changes from Resend to external systems when contacts are created, updated, or deleted.
+
+**Use Case**: Keep your CRM, database, or marketing tools in sync with your Resend audience.
+
+**Nodes Used**:
+
+- Resend Trigger (contact.created, contact.updated, contact.deleted events)
+- Switch (routes by event type)
+- HTTP Request (syncs to external API)
+
+**Key Features**:
+
+- Real-time contact synchronization
+- Event-type routing
+- External system integration
+
+---
+
+### 3. Human-in-the-Loop: Approval Workflow (`human-in-loop-approval.json`)
+
+**Description**: Implements an approval workflow where content or requests are sent via email for manager approval. The workflow pauses until the recipient clicks Approve or Decline.
+
+**Use Case**: Document approval, expense requests, content publishing approval, access requests.
+
+**Nodes Used**:
+
+- Manual Trigger (initiates approval)
+- Resend (Send and Wait for Approval)
+- IF (routes based on approval decision)
+- Slack or HTTP Request (notifies of outcome)
+
+**Key Features**:
+
+- Dual button (Approve/Decline) options
+- Automatic workflow pause and resume
+- Customizable button labels and styling
+- Configurable timeout
+
+---
+
+### 4. Human-in-the-Loop: Free Text Response (`human-in-loop-freetext.json`)
+
+**Description**: Sends an email requesting feedback or input, with a link to a form where the recipient can provide a free-text response. Perfect for collecting qualitative feedback.
+
+**Use Case**: Customer feedback collection, survey responses, support ticket updates, interview scheduling.
+
+**Nodes Used**:
+
+- Schedule Trigger (daily/weekly triggers)
+- Resend (Send and Wait for Free Text)
+- Code (processes response)
+- Notion or Airtable (stores responses)
+
+**Key Features**:
+
+- Form-based response collection
+- Automatic response processing
+- Integration with databases
+
+---
+
+### 5. Contact & Audience Management (`contact-audience-management.json`)
+
+**Description**: Demonstrates comprehensive contact management including creating audiences, adding contacts, managing segments, and handling topic subscriptions.
+
+**Use Case**: Newsletter signup automation, contact segmentation, preference management.
+
+**Nodes Used**:
+
+- Webhook (receives signup data)
+- Resend (Audience: list, Contact: create, Segment: add)
+- Resend (Topic: update subscriptions)
+
+**Key Features**:
+
+- Dynamic audience selection
+- Segment-based grouping
+- Topic subscription management
+- Contact property handling
+
+---
+
+### 6. Broadcast Campaign Automation (`broadcast-automation.json`)
+
+**Description**: Creates and schedules broadcast email campaigns using templates, with automatic audience targeting and scheduling.
+
+**Use Case**: Newsletter distribution, marketing campaigns, product announcements.
+
+**Nodes Used**:
+
+- Schedule Trigger (weekly trigger)
+- Resend (Broadcast: create, update, send)
+- Resend (Template: get)
+
+**Key Features**:
+
+- Template-based content
+- Scheduled sending
+- Audience targeting
+- Broadcast status tracking
+
+---
+
+### 7. Domain & Webhook Management (`domain-webhook-setup.json`)
+
+**Description**: Automates domain verification and webhook configuration for new Resend accounts or domain additions.
+
+**Use Case**: Onboarding automation, multi-tenant email setup, infrastructure management.
+
+**Nodes Used**:
+
+- Manual Trigger
+- Resend (Domain: create, verify)
+- Resend (Webhook: create, list)
+
+**Key Features**:
+
+- Domain DNS verification
+- Webhook endpoint registration
+- Event subscription configuration
+
+---
+
+## Prerequisites
+
+Before using these workflows, ensure you have:
+
+1. **Resend Account**: Sign up at [resend.com](https://resend.com)
+2. **API Key**: Generate from your Resend dashboard
+3. **Verified Domain** (for sending): Add and verify your sending domain
+4. **n8n-nodes-resend Installed**: Install this community node in your n8n instance
+
+## Credential Setup
+
+1. In n8n, go to **Credentials** → **Add Credential**
+2. Search for "Resend API"
+3. Enter your Resend API key
+4. Test the connection and save
+
+## Webhook Configuration (for Trigger Workflows)
+
+For workflows using the **Resend Trigger** node:
+
+1. Note the webhook URL shown in the trigger node
+2. Go to your [Resend Dashboard](https://resend.com/webhooks)
+3. Click **Add Webhook**
+4. Paste the n8n webhook URL
+5. Select the events you want to receive
+6. Copy the **Signing Secret** (starts with `whsec_`)
+7. Paste the signing secret into the trigger node's configuration
+
+## Tips
+
+- **Test Mode**: Use the "Listen for test event" mode when building workflows
+- **Production Mode**: Activate the workflow and use the production URL for live data
+- **Error Handling**: Consider adding Error Trigger nodes to handle failures gracefully
+- **Rate Limits**: Be aware of Resend API rate limits for high-volume operations
+
+## Support
+
+For issues with:
+
+- **These examples**: Open an issue in this repository
+- **Resend API**: Check [Resend Documentation](https://resend.com/docs)
+- **n8n**: Visit [n8n Documentation](https://docs.n8n.io)

--- a/examples/broadcast-automation.json
+++ b/examples/broadcast-automation.json
@@ -49,11 +49,12 @@
     },
     {
       "parameters": {
-        "resource": "templates",
-        "operation": "list"
+        "resource": "segments",
+        "operation": "list",
+        "audienceId": "={{ $json.audience_id }}"
       },
-      "id": "resend-templates-1",
-      "name": "Get Templates",
+      "id": "resend-segments-1",
+      "name": "Get Segments",
       "type": "n8n-nodes-resend.resend",
       "typeVersion": 1,
       "position": [900, 300],
@@ -66,10 +67,10 @@
     },
     {
       "parameters": {
-        "jsCode": "// Select the weekly newsletter template\nconst templates = $input.first().json.data || [];\nconst audienceData = $('Select Audience').first().json;\n\nif (templates.length === 0) {\n  // No template found, we'll use inline HTML\n  return [{\n    json: {\n      ...audienceData,\n      use_template: false,\n      template_id: null,\n      html_content: `\n        <h1>Weekly Update - ${new Date().toLocaleDateString()}</h1>\n        <p>Hello there!</p>\n        <p>Here's what's new this week:</p>\n        <ul>\n          <li>Feature updates and improvements</li>\n          <li>Tips and best practices</li>\n          <li>Community highlights</li>\n        </ul>\n        <p>Stay tuned for more updates!</p>\n        <p>Best,<br>The Team</p>\n      `\n    }\n  }];\n}\n\n// Find weekly newsletter template\nlet template = templates.find(t => \n  t.name.toLowerCase().includes('weekly') || \n  t.name.toLowerCase().includes('newsletter')\n);\n\n// Fallback to first template\nif (!template) {\n  template = templates[0];\n}\n\nreturn [{\n  json: {\n    ...audienceData,\n    use_template: true,\n    template_id: template.id,\n    template_name: template.name\n  }\n}];"
+        "jsCode": "// Select a segment for the broadcast\nconst segments = $input.first().json.data || [];\nconst audienceData = $('Select Audience').first().json;\n\nif (segments.length === 0) {\n  throw new Error('No segments found. Please create a segment in your audience first.');\n}\n\n// Find newsletter or weekly segment, or use first available\nlet targetSegment = segments.find(s => \n  s.name.toLowerCase().includes('newsletter') || \n  s.name.toLowerCase().includes('weekly') ||\n  s.name.toLowerCase().includes('all')\n);\n\n// Fallback to first segment\nif (!targetSegment) {\n  targetSegment = segments[0];\n}\n\nreturn [{\n  json: {\n    ...audienceData,\n    segment_id: targetSegment.id,\n    segment_name: targetSegment.name\n  }\n}];"
       },
-      "id": "code-2",
-      "name": "Select Template",
+      "id": "code-segments-1",
+      "name": "Select Segment",
       "type": "n8n-nodes-base.code",
       "typeVersion": 2,
       "position": [1120, 300]
@@ -78,13 +79,12 @@
       "parameters": {
         "resource": "broadcasts",
         "operation": "create",
-        "audienceId": "={{ $json.audience_id }}",
-        "from": "newsletter@yourdomain.com",
-        "subject": "={{ $json.campaign_name }}",
-        "additionalFields": {
-          "name": "={{ $json.campaign_name }}",
-          "previewText": "Your weekly dose of updates and insights",
-          "html": "={{ $json.use_template ? undefined : $json.html_content }}"
+        "segmentId": "={{ $json.segment_id }}",
+        "broadcastFrom": "newsletter@yourdomain.com",
+        "broadcastSubject": "={{ $json.campaign_name }}",
+        "broadcastHtml": "={{ $json.html_content || '<h1>Weekly Update - ' + new Date().toLocaleDateString() + '</h1><p>Hello there!</p><p>Here\\'s what\\'s new this week.</p><p><a href=\"{{{RESEND_UNSUBSCRIBE_URL}}}\">Unsubscribe</a></p>' }}",
+        "broadcastCreateOptions": {
+          "name": "={{ $json.campaign_name }}"
         }
       },
       "id": "resend-broadcast-create-1",
@@ -97,7 +97,8 @@
           "id": "",
           "name": "Resend API"
         }
-      }
+      },
+      "continueOnFail": true
     },
     {
       "parameters": {
@@ -172,7 +173,7 @@
     },
     {
       "parameters": {
-        "content": "## Broadcast Campaign Automation\n\nThis workflow automates weekly newsletter broadcasts using Resend.\n\n### Flow:\n1. **Schedule**: Triggers every Friday at 9 AM\n2. **Get Audiences**: Fetches available audiences\n3. **Select Audience**: Picks newsletter audience\n4. **Get Templates**: Lists available templates\n5. **Select Template**: Picks newsletter template (or uses inline HTML)\n6. **Create Broadcast**: Creates the campaign\n7. **Send Broadcast**: Sends to all contacts in audience\n8. **Notify**: Alerts team on Slack\n\n### Configuration:\n1. Set up Resend credentials\n2. Create an audience and add contacts\n3. Optionally create a reusable template\n4. Update sender email (verified domain)\n5. Configure Slack for notifications (optional)\n\n### Customization:\n- Change schedule trigger for different timing\n- Add content from external sources (CMS, RSS)\n- Include dynamic content per recipient"
+        "content": "## Broadcast Campaign Automation\n\nThis workflow automates weekly newsletter broadcasts using Resend.\n\n### Flow:\n1. **Schedule**: Triggers every Friday at 9 AM\n2. **Get Audiences**: Fetches available audiences\n3. **Select Audience**: Picks newsletter audience\n4. **Get Segments**: Lists segments in that audience\n5. **Select Segment**: Picks target segment (required for broadcasts)\n6. **Create Broadcast**: Creates the campaign with HTML content\n7. **Send Broadcast**: Sends to all contacts in segment\n8. **Notify**: Alerts team on Slack\n\n### Configuration:\n1. Set up Resend credentials\n2. Create an audience with contacts\n3. Create a segment in the audience\n4. Update sender email (verified domain)\n5. Include {{{RESEND_UNSUBSCRIBE_URL}}} in HTML content\n\n### Customization:\n- Change schedule trigger for different timing\n- Modify HTML content or add dynamic content\n- Connect to CMS for content sourcing"
       },
       "id": "note-1",
       "name": "Sticky Note",
@@ -208,25 +209,25 @@
       "main": [
         [
           {
-            "node": "Get Templates",
+            "node": "Get Segments",
             "type": "main",
             "index": 0
           }
         ]
       ]
     },
-    "Get Templates": {
+    "Get Segments": {
       "main": [
         [
           {
-            "node": "Select Template",
+            "node": "Select Segment",
             "type": "main",
             "index": 0
           }
         ]
       ]
     },
-    "Select Template": {
+    "Select Segment": {
       "main": [
         [
           {

--- a/examples/broadcast-automation.json
+++ b/examples/broadcast-automation.json
@@ -1,0 +1,288 @@
+{
+  "name": "Resend - Broadcast Campaign Automation",
+  "nodes": [
+    {
+      "parameters": {
+        "rule": {
+          "interval": [
+            {
+              "field": "weeks",
+              "weekInterval": 1,
+              "triggerAtDay": [5],
+              "triggerAtHour": 9
+            }
+          ]
+        }
+      },
+      "id": "schedule-1",
+      "name": "Weekly Friday 9 AM",
+      "type": "n8n-nodes-base.scheduleTrigger",
+      "typeVersion": 1.2,
+      "position": [240, 300]
+    },
+    {
+      "parameters": {
+        "resource": "audiences",
+        "operation": "list"
+      },
+      "id": "resend-audience-1",
+      "name": "Get Audiences",
+      "type": "n8n-nodes-resend.resend",
+      "typeVersion": 1,
+      "position": [460, 300],
+      "credentials": {
+        "resendApi": {
+          "id": "",
+          "name": "Resend API"
+        }
+      }
+    },
+    {
+      "parameters": {
+        "jsCode": "// Select the primary newsletter audience\nconst audiences = $input.first().json.data || [];\n\nif (audiences.length === 0) {\n  throw new Error('No audiences found. Please create an audience in Resend first.');\n}\n\n// Find newsletter or subscribers audience\nlet targetAudience = audiences.find(a => \n  a.name.toLowerCase().includes('newsletter') || \n  a.name.toLowerCase().includes('weekly')\n);\n\n// Fallback to first audience\nif (!targetAudience) {\n  targetAudience = audiences[0];\n}\n\nreturn [{\n  json: {\n    audience_id: targetAudience.id,\n    audience_name: targetAudience.name,\n    campaign_date: new Date().toISOString().split('T')[0],\n    campaign_name: `Weekly Update - ${new Date().toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' })}`\n  }\n}];"
+      },
+      "id": "code-1",
+      "name": "Select Audience",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [680, 300]
+    },
+    {
+      "parameters": {
+        "resource": "templates",
+        "operation": "list"
+      },
+      "id": "resend-templates-1",
+      "name": "Get Templates",
+      "type": "n8n-nodes-resend.resend",
+      "typeVersion": 1,
+      "position": [900, 300],
+      "credentials": {
+        "resendApi": {
+          "id": "",
+          "name": "Resend API"
+        }
+      }
+    },
+    {
+      "parameters": {
+        "jsCode": "// Select the weekly newsletter template\nconst templates = $input.first().json.data || [];\nconst audienceData = $('Select Audience').first().json;\n\nif (templates.length === 0) {\n  // No template found, we'll use inline HTML\n  return [{\n    json: {\n      ...audienceData,\n      use_template: false,\n      template_id: null,\n      html_content: `\n        <h1>Weekly Update - ${new Date().toLocaleDateString()}</h1>\n        <p>Hello there!</p>\n        <p>Here's what's new this week:</p>\n        <ul>\n          <li>Feature updates and improvements</li>\n          <li>Tips and best practices</li>\n          <li>Community highlights</li>\n        </ul>\n        <p>Stay tuned for more updates!</p>\n        <p>Best,<br>The Team</p>\n      `\n    }\n  }];\n}\n\n// Find weekly newsletter template\nlet template = templates.find(t => \n  t.name.toLowerCase().includes('weekly') || \n  t.name.toLowerCase().includes('newsletter')\n);\n\n// Fallback to first template\nif (!template) {\n  template = templates[0];\n}\n\nreturn [{\n  json: {\n    ...audienceData,\n    use_template: true,\n    template_id: template.id,\n    template_name: template.name\n  }\n}];"
+      },
+      "id": "code-2",
+      "name": "Select Template",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [1120, 300]
+    },
+    {
+      "parameters": {
+        "resource": "broadcasts",
+        "operation": "create",
+        "audienceId": "={{ $json.audience_id }}",
+        "from": "newsletter@yourdomain.com",
+        "subject": "={{ $json.campaign_name }}",
+        "additionalFields": {
+          "name": "={{ $json.campaign_name }}",
+          "previewText": "Your weekly dose of updates and insights",
+          "html": "={{ $json.use_template ? undefined : $json.html_content }}"
+        }
+      },
+      "id": "resend-broadcast-create-1",
+      "name": "Create Broadcast",
+      "type": "n8n-nodes-resend.resend",
+      "typeVersion": 1,
+      "position": [1340, 300],
+      "credentials": {
+        "resendApi": {
+          "id": "",
+          "name": "Resend API"
+        }
+      }
+    },
+    {
+      "parameters": {
+        "conditions": {
+          "options": {
+            "caseSensitive": true,
+            "leftValue": "",
+            "typeValidation": "strict"
+          },
+          "conditions": [
+            {
+              "leftValue": "={{ $json.id }}",
+              "rightValue": "",
+              "operator": {
+                "type": "string",
+                "operation": "notEmpty"
+              }
+            }
+          ],
+          "combinator": "and"
+        }
+      },
+      "id": "if-1",
+      "name": "Broadcast Created?",
+      "type": "n8n-nodes-base.if",
+      "typeVersion": 2,
+      "position": [1560, 300]
+    },
+    {
+      "parameters": {
+        "resource": "broadcasts",
+        "operation": "send",
+        "broadcastId": "={{ $json.id }}"
+      },
+      "id": "resend-broadcast-send-1",
+      "name": "Send Broadcast",
+      "type": "n8n-nodes-resend.resend",
+      "typeVersion": 1,
+      "position": [1780, 180],
+      "credentials": {
+        "resendApi": {
+          "id": "",
+          "name": "Resend API"
+        }
+      }
+    },
+    {
+      "parameters": {
+        "channel": "#marketing",
+        "text": "=📨 *Weekly Newsletter Sent!*\n\n*Campaign:* {{ $('Select Audience').item.json.campaign_name }}\n*Audience:* {{ $('Select Audience').item.json.audience_name }}\n*Broadcast ID:* {{ $('Create Broadcast').item.json.id }}\n*Sent at:* {{ new Date().toISOString() }}",
+        "otherOptions": {}
+      },
+      "id": "slack-1",
+      "name": "Notify Team on Slack",
+      "type": "n8n-nodes-base.slack",
+      "typeVersion": 2.1,
+      "position": [2000, 180],
+      "notes": "Optional: Configure Slack credentials"
+    },
+    {
+      "parameters": {
+        "channel": "#marketing",
+        "text": "=⚠️ *Broadcast Creation Failed*\n\nCampaign: {{ $('Select Audience').item.json.campaign_name }}\nError: Check execution logs for details",
+        "otherOptions": {}
+      },
+      "id": "slack-error-1",
+      "name": "Alert on Failure",
+      "type": "n8n-nodes-base.slack",
+      "typeVersion": 2.1,
+      "position": [1780, 420],
+      "notes": "Optional: Configure Slack credentials"
+    },
+    {
+      "parameters": {
+        "content": "## Broadcast Campaign Automation\n\nThis workflow automates weekly newsletter broadcasts using Resend.\n\n### Flow:\n1. **Schedule**: Triggers every Friday at 9 AM\n2. **Get Audiences**: Fetches available audiences\n3. **Select Audience**: Picks newsletter audience\n4. **Get Templates**: Lists available templates\n5. **Select Template**: Picks newsletter template (or uses inline HTML)\n6. **Create Broadcast**: Creates the campaign\n7. **Send Broadcast**: Sends to all contacts in audience\n8. **Notify**: Alerts team on Slack\n\n### Configuration:\n1. Set up Resend credentials\n2. Create an audience and add contacts\n3. Optionally create a reusable template\n4. Update sender email (verified domain)\n5. Configure Slack for notifications (optional)\n\n### Customization:\n- Change schedule trigger for different timing\n- Add content from external sources (CMS, RSS)\n- Include dynamic content per recipient"
+      },
+      "id": "note-1",
+      "name": "Sticky Note",
+      "type": "n8n-nodes-base.stickyNote",
+      "typeVersion": 1,
+      "position": [200, 40]
+    }
+  ],
+  "connections": {
+    "Weekly Friday 9 AM": {
+      "main": [
+        [
+          {
+            "node": "Get Audiences",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Get Audiences": {
+      "main": [
+        [
+          {
+            "node": "Select Audience",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Select Audience": {
+      "main": [
+        [
+          {
+            "node": "Get Templates",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Get Templates": {
+      "main": [
+        [
+          {
+            "node": "Select Template",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Select Template": {
+      "main": [
+        [
+          {
+            "node": "Create Broadcast",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Create Broadcast": {
+      "main": [
+        [
+          {
+            "node": "Broadcast Created?",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Broadcast Created?": {
+      "main": [
+        [
+          {
+            "node": "Send Broadcast",
+            "type": "main",
+            "index": 0
+          }
+        ],
+        [
+          {
+            "node": "Alert on Failure",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Send Broadcast": {
+      "main": [
+        [
+          {
+            "node": "Notify Team on Slack",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    }
+  },
+  "settings": {
+    "executionOrder": "v1"
+  },
+  "staticData": null,
+  "tags": [],
+  "triggerCount": 1,
+  "pinData": {}
+}

--- a/examples/contact-audience-management.json
+++ b/examples/contact-audience-management.json
@@ -1,0 +1,298 @@
+{
+  "name": "Resend - Contact & Audience Management",
+  "nodes": [
+    {
+      "parameters": {
+        "httpMethod": "POST",
+        "path": "newsletter-signup",
+        "responseMode": "responseNode",
+        "options": {}
+      },
+      "id": "webhook-1",
+      "name": "Newsletter Signup Webhook",
+      "type": "n8n-nodes-base.webhook",
+      "typeVersion": 2,
+      "position": [240, 300],
+      "webhookId": "newsletter-signup"
+    },
+    {
+      "parameters": {
+        "jsCode": "// Validate and process signup data\nconst body = $input.first().json.body;\n\nif (!body.email || !body.email.includes('@')) {\n  throw new Error('Valid email is required');\n}\n\nreturn [{\n  json: {\n    email: body.email.toLowerCase().trim(),\n    first_name: body.first_name || '',\n    last_name: body.last_name || '',\n    interests: body.interests || [],\n    source: body.source || 'website',\n    subscribed_at: new Date().toISOString()\n  }\n}];"
+      },
+      "id": "code-1",
+      "name": "Validate Signup Data",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [460, 300]
+    },
+    {
+      "parameters": {
+        "resource": "audiences",
+        "operation": "list"
+      },
+      "id": "resend-audience-1",
+      "name": "Get Audiences",
+      "type": "n8n-nodes-resend.resend",
+      "typeVersion": 1,
+      "position": [680, 300],
+      "credentials": {
+        "resendApi": {
+          "id": "",
+          "name": "Resend API"
+        }
+      }
+    },
+    {
+      "parameters": {
+        "jsCode": "// Find the Newsletter audience or use the first one\nconst audiences = $input.first().json.data;\nconst signupData = $('Validate Signup Data').first().json;\n\nlet targetAudience = audiences.find(a => \n  a.name.toLowerCase().includes('newsletter') || \n  a.name.toLowerCase().includes('subscribers')\n);\n\n// Fall back to first audience if no newsletter audience found\nif (!targetAudience && audiences.length > 0) {\n  targetAudience = audiences[0];\n}\n\nif (!targetAudience) {\n  throw new Error('No audience found. Please create an audience in Resend first.');\n}\n\nreturn [{\n  json: {\n    ...signupData,\n    audience_id: targetAudience.id,\n    audience_name: targetAudience.name\n  }\n}];"
+      },
+      "id": "code-2",
+      "name": "Select Target Audience",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [900, 300]
+    },
+    {
+      "parameters": {
+        "resource": "contacts",
+        "operation": "create",
+        "audienceId": "={{ $json.audience_id }}",
+        "email": "={{ $json.email }}",
+        "additionalFields": {
+          "firstName": "={{ $json.first_name }}",
+          "lastName": "={{ $json.last_name }}",
+          "unsubscribed": false
+        }
+      },
+      "id": "resend-contact-1",
+      "name": "Create Contact",
+      "type": "n8n-nodes-resend.resend",
+      "typeVersion": 1,
+      "position": [1120, 300],
+      "credentials": {
+        "resendApi": {
+          "id": "",
+          "name": "Resend API"
+        }
+      },
+      "continueOnFail": true
+    },
+    {
+      "parameters": {
+        "conditions": {
+          "options": {
+            "caseSensitive": true,
+            "leftValue": "",
+            "typeValidation": "strict"
+          },
+          "conditions": [
+            {
+              "leftValue": "={{ $json.id }}",
+              "rightValue": "",
+              "operator": {
+                "type": "string",
+                "operation": "notEmpty"
+              }
+            }
+          ],
+          "combinator": "and"
+        }
+      },
+      "id": "if-1",
+      "name": "Contact Created?",
+      "type": "n8n-nodes-base.if",
+      "typeVersion": 2,
+      "position": [1340, 300]
+    },
+    {
+      "parameters": {
+        "resource": "segments",
+        "operation": "list",
+        "audienceId": "={{ $('Select Target Audience').item.json.audience_id }}"
+      },
+      "id": "resend-segments-1",
+      "name": "Get Available Segments",
+      "type": "n8n-nodes-resend.resend",
+      "typeVersion": 1,
+      "position": [1560, 180],
+      "credentials": {
+        "resendApi": {
+          "id": "",
+          "name": "Resend API"
+        }
+      }
+    },
+    {
+      "parameters": {
+        "resource": "email",
+        "operation": "send",
+        "fromEmail": "welcome@yourdomain.com",
+        "toEmail": "={{ $('Select Target Audience').item.json.email }}",
+        "subject": "Welcome to our Newsletter! 🎉",
+        "emailType": "html",
+        "htmlBody": "=<h1>Welcome, {{ $('Select Target Audience').item.json.first_name || 'Friend' }}!</h1>\n<p>Thank you for subscribing to our newsletter. We're excited to have you!</p>\n<p>Here's what you can expect:</p>\n<ul>\n<li>Weekly updates and insights</li>\n<li>Exclusive content and offers</li>\n<li>Early access to new features</li>\n</ul>\n<p>Stay tuned for our next update!</p>\n<p>Best regards,<br>The Team</p>"
+      },
+      "id": "resend-welcome-1",
+      "name": "Send Welcome Email",
+      "type": "n8n-nodes-resend.resend",
+      "typeVersion": 1,
+      "position": [1780, 180],
+      "credentials": {
+        "resendApi": {
+          "id": "",
+          "name": "Resend API"
+        }
+      }
+    },
+    {
+      "parameters": {
+        "respondWith": "json",
+        "responseBody": "={\n  \"success\": true,\n  \"message\": \"Successfully subscribed!\",\n  \"email\": \"{{ $('Select Target Audience').item.json.email }}\"\n}",
+        "options": {
+          "responseCode": 200,
+          "responseHeaders": {
+            "entries": [
+              {
+                "name": "Content-Type",
+                "value": "application/json"
+              }
+            ]
+          }
+        }
+      },
+      "id": "respond-success-1",
+      "name": "Respond Success",
+      "type": "n8n-nodes-base.respondToWebhook",
+      "typeVersion": 1.1,
+      "position": [2000, 180]
+    },
+    {
+      "parameters": {
+        "respondWith": "json",
+        "responseBody": "={\n  \"success\": false,\n  \"message\": \"Email already subscribed or invalid\"\n}",
+        "options": {
+          "responseCode": 400
+        }
+      },
+      "id": "respond-error-1",
+      "name": "Respond Error",
+      "type": "n8n-nodes-base.respondToWebhook",
+      "typeVersion": 1.1,
+      "position": [1560, 420]
+    },
+    {
+      "parameters": {
+        "content": "## Contact & Audience Management Workflow\n\nThis workflow handles newsletter signups through a webhook and manages contacts in Resend.\n\n### Flow:\n1. **Webhook**: Receives signup from website form\n2. **Validate**: Checks email format and cleans data\n3. **Get Audiences**: Lists available audiences\n4. **Select Audience**: Picks the newsletter audience\n5. **Create Contact**: Adds contact to Resend\n6. **Send Welcome**: Sends welcome email to new subscriber\n7. **Respond**: Returns success/error to the website\n\n### Integration Points:\n- Works with any frontend form\n- Returns JSON response for AJAX handling\n- Handles duplicate emails gracefully\n\n### Setup:\n1. Configure Resend credentials\n2. Create an audience in Resend dashboard\n3. Update sender email (must be verified domain)\n4. Get the webhook URL and use in your signup form"
+      },
+      "id": "note-1",
+      "name": "Sticky Note",
+      "type": "n8n-nodes-base.stickyNote",
+      "typeVersion": 1,
+      "position": [200, 40]
+    }
+  ],
+  "connections": {
+    "Newsletter Signup Webhook": {
+      "main": [
+        [
+          {
+            "node": "Validate Signup Data",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Validate Signup Data": {
+      "main": [
+        [
+          {
+            "node": "Get Audiences",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Get Audiences": {
+      "main": [
+        [
+          {
+            "node": "Select Target Audience",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Select Target Audience": {
+      "main": [
+        [
+          {
+            "node": "Create Contact",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Create Contact": {
+      "main": [
+        [
+          {
+            "node": "Contact Created?",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Contact Created?": {
+      "main": [
+        [
+          {
+            "node": "Get Available Segments",
+            "type": "main",
+            "index": 0
+          }
+        ],
+        [
+          {
+            "node": "Respond Error",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Get Available Segments": {
+      "main": [
+        [
+          {
+            "node": "Send Welcome Email",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Send Welcome Email": {
+      "main": [
+        [
+          {
+            "node": "Respond Success",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    }
+  },
+  "settings": {
+    "executionOrder": "v1"
+  },
+  "staticData": null,
+  "tags": [],
+  "triggerCount": 1,
+  "pinData": {}
+}

--- a/examples/contact-audience-management.json
+++ b/examples/contact-audience-management.json
@@ -130,7 +130,7 @@
         "toEmail": "={{ $('Select Target Audience').item.json.email }}",
         "subject": "Welcome to our Newsletter! 🎉",
         "emailType": "html",
-        "htmlBody": "=<h1>Welcome, {{ $('Select Target Audience').item.json.first_name || 'Friend' }}!</h1>\n<p>Thank you for subscribing to our newsletter. We're excited to have you!</p>\n<p>Here's what you can expect:</p>\n<ul>\n<li>Weekly updates and insights</li>\n<li>Exclusive content and offers</li>\n<li>Early access to new features</li>\n</ul>\n<p>Stay tuned for our next update!</p>\n<p>Best regards,<br>The Team</p>"
+        "htmlBody": "={{ `<h1>Welcome, ${$('Select Target Audience').item.json.first_name || 'Friend'}!</h1><p>Thank you for subscribing to our newsletter. We're excited to have you!</p><p>Here's what you can expect:</p><ul><li>Weekly updates and insights</li><li>Exclusive content and offers</li><li>Early access to new features</li></ul><p>Stay tuned for our next update!</p><p>Best regards,<br>The Team</p>` }}"
       },
       "id": "resend-welcome-1",
       "name": "Send Welcome Email",
@@ -147,7 +147,7 @@
     {
       "parameters": {
         "respondWith": "json",
-        "responseBody": "={\n  \"success\": true,\n  \"message\": \"Successfully subscribed!\",\n  \"email\": \"{{ $('Select Target Audience').item.json.email }}\"\n}",
+        "responseBody": "={{ JSON.stringify({ success: true, message: 'Successfully subscribed!', email: $('Select Target Audience').item.json.email }) }}",
         "options": {
           "responseCode": 200,
           "responseHeaders": {

--- a/examples/domain-webhook-setup.json
+++ b/examples/domain-webhook-setup.json
@@ -1,0 +1,345 @@
+{
+  "name": "Resend - Domain & Webhook Setup",
+  "nodes": [
+    {
+      "parameters": {},
+      "id": "manual-trigger-1",
+      "name": "Manual Trigger",
+      "type": "n8n-nodes-base.manualTrigger",
+      "typeVersion": 1,
+      "position": [240, 300]
+    },
+    {
+      "parameters": {
+        "mode": "raw",
+        "jsonOutput": "{\n  \"domain\": \"yourdomain.com\",\n  \"webhook_endpoint\": \"https://your-n8n-instance.com/webhook/resend-events\",\n  \"events_to_subscribe\": [\n    \"email.sent\",\n    \"email.delivered\",\n    \"email.opened\",\n    \"email.clicked\",\n    \"email.bounced\",\n    \"email.complained\"\n  ]\n}",
+        "options": {}
+      },
+      "id": "set-1",
+      "name": "Configuration",
+      "type": "n8n-nodes-base.set",
+      "typeVersion": 3.3,
+      "position": [460, 300],
+      "notes": "Edit these values for your setup"
+    },
+    {
+      "parameters": {
+        "resource": "domains",
+        "operation": "list"
+      },
+      "id": "resend-domains-list-1",
+      "name": "List Existing Domains",
+      "type": "n8n-nodes-resend.resend",
+      "typeVersion": 1,
+      "position": [680, 300],
+      "credentials": {
+        "resendApi": {
+          "id": "",
+          "name": "Resend API"
+        }
+      }
+    },
+    {
+      "parameters": {
+        "jsCode": "// Check if domain already exists\nconst domains = $input.first().json.data || [];\nconst config = $('Configuration').first().json;\nconst targetDomain = config.domain;\n\nconst existingDomain = domains.find(d => d.name === targetDomain);\n\nif (existingDomain) {\n  return [{\n    json: {\n      ...config,\n      domain_exists: true,\n      domain_id: existingDomain.id,\n      domain_status: existingDomain.status,\n      domain_records: existingDomain.records || []\n    }\n  }];\n}\n\nreturn [{\n  json: {\n    ...config,\n    domain_exists: false,\n    domain_id: null,\n    domain_status: 'not_created'\n  }\n}];"
+      },
+      "id": "code-1",
+      "name": "Check Domain Status",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [900, 300]
+    },
+    {
+      "parameters": {
+        "conditions": {
+          "options": {
+            "caseSensitive": true,
+            "leftValue": "",
+            "typeValidation": "strict"
+          },
+          "conditions": [
+            {
+              "leftValue": "={{ $json.domain_exists }}",
+              "rightValue": true,
+              "operator": {
+                "type": "boolean",
+                "operation": "equals"
+              }
+            }
+          ],
+          "combinator": "and"
+        }
+      },
+      "id": "if-domain-1",
+      "name": "Domain Exists?",
+      "type": "n8n-nodes-base.if",
+      "typeVersion": 2,
+      "position": [1120, 300]
+    },
+    {
+      "parameters": {
+        "resource": "domains",
+        "operation": "create",
+        "name": "={{ $('Configuration').item.json.domain }}"
+      },
+      "id": "resend-domain-create-1",
+      "name": "Create Domain",
+      "type": "n8n-nodes-resend.resend",
+      "typeVersion": 1,
+      "position": [1340, 420],
+      "credentials": {
+        "resendApi": {
+          "id": "",
+          "name": "Resend API"
+        }
+      }
+    },
+    {
+      "parameters": {
+        "jsCode": "// Prepare DNS records for output\nconst domainData = $input.first().json;\nconst config = $('Configuration').first().json;\n\n// Handle both existing domain and newly created domain\nlet records = domainData.records || domainData.domain_records || [];\nlet domainId = domainData.id || domainData.domain_id;\nlet status = domainData.status || domainData.domain_status;\n\nreturn [{\n  json: {\n    domain: config.domain,\n    domain_id: domainId,\n    status: status,\n    dns_records: records,\n    setup_instructions: records.length > 0 ? \n      'Add the following DNS records to your domain provider' : \n      'DNS records will be available once the domain is processed'\n  }\n}];"
+      },
+      "id": "code-2",
+      "name": "Format Domain Info",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [1560, 300]
+    },
+    {
+      "parameters": {
+        "resource": "webhooks",
+        "operation": "list"
+      },
+      "id": "resend-webhooks-list-1",
+      "name": "List Existing Webhooks",
+      "type": "n8n-nodes-resend.resend",
+      "typeVersion": 1,
+      "position": [1780, 300],
+      "credentials": {
+        "resendApi": {
+          "id": "",
+          "name": "Resend API"
+        }
+      }
+    },
+    {
+      "parameters": {
+        "jsCode": "// Check if webhook already exists for our endpoint\nconst webhooks = $input.first().json.data || [];\nconst config = $('Configuration').first().json;\nconst domainInfo = $('Format Domain Info').first().json;\nconst targetEndpoint = config.webhook_endpoint;\n\nconst existingWebhook = webhooks.find(w => w.endpoint_url === targetEndpoint);\n\nreturn [{\n  json: {\n    ...domainInfo,\n    webhook_endpoint: targetEndpoint,\n    events_to_subscribe: config.events_to_subscribe,\n    webhook_exists: !!existingWebhook,\n    existing_webhook_id: existingWebhook?.id || null\n  }\n}];"
+      },
+      "id": "code-3",
+      "name": "Check Webhook Status",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [2000, 300]
+    },
+    {
+      "parameters": {
+        "conditions": {
+          "options": {
+            "caseSensitive": true,
+            "leftValue": "",
+            "typeValidation": "strict"
+          },
+          "conditions": [
+            {
+              "leftValue": "={{ $json.webhook_exists }}",
+              "rightValue": true,
+              "operator": {
+                "type": "boolean",
+                "operation": "equals"
+              }
+            }
+          ],
+          "combinator": "and"
+        }
+      },
+      "id": "if-webhook-1",
+      "name": "Webhook Exists?",
+      "type": "n8n-nodes-base.if",
+      "typeVersion": 2,
+      "position": [2220, 300]
+    },
+    {
+      "parameters": {
+        "resource": "webhooks",
+        "operation": "create",
+        "endpointUrl": "={{ $json.webhook_endpoint }}",
+        "events": "={{ $json.events_to_subscribe }}"
+      },
+      "id": "resend-webhook-create-1",
+      "name": "Create Webhook",
+      "type": "n8n-nodes-resend.resend",
+      "typeVersion": 1,
+      "position": [2440, 420],
+      "credentials": {
+        "resendApi": {
+          "id": "",
+          "name": "Resend API"
+        }
+      }
+    },
+    {
+      "parameters": {
+        "jsCode": "// Generate final setup report\nconst input = $input.first().json;\nconst config = $('Configuration').first().json;\nconst domainInfo = $('Format Domain Info').first().json;\n\n// Check if this is from the webhook creation or the existing webhook path\nconst webhookId = input.id || input.existing_webhook_id;\nconst webhookSecret = input.signing_secret || 'Use existing webhook secret';\n\nconst report = {\n  setup_complete: true,\n  timestamp: new Date().toISOString(),\n  domain: {\n    name: config.domain,\n    id: domainInfo.domain_id,\n    status: domainInfo.status,\n    dns_records: domainInfo.dns_records\n  },\n  webhook: {\n    id: webhookId,\n    endpoint: config.webhook_endpoint,\n    events: config.events_to_subscribe,\n    signing_secret: webhookSecret\n  },\n  next_steps: [\n    'Add DNS records to your domain provider',\n    'Wait for domain verification (usually 24-48 hours)',\n    'Store the webhook signing secret securely',\n    'Configure your Resend Trigger node with the signing secret'\n  ]\n};\n\nreturn [{ json: report }];"
+      },
+      "id": "code-4",
+      "name": "Generate Setup Report",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [2660, 300]
+    },
+    {
+      "parameters": {
+        "content": "## Domain & Webhook Setup Workflow\n\nThis workflow automates the initial setup of domains and webhooks in Resend.\n\n### What It Does:\n1. **Check Domain**: Lists existing domains, creates if needed\n2. **DNS Records**: Returns DNS records to configure at your registrar\n3. **Check Webhook**: Lists existing webhooks\n4. **Create Webhook**: Sets up webhook for event notifications\n5. **Report**: Generates setup summary with next steps\n\n### Configuration:\nEdit the 'Configuration' node to set:\n- Your sending domain\n- Your n8n webhook endpoint URL\n- Events to subscribe to\n\n### After Running:\n1. Copy DNS records to your domain registrar\n2. Save the webhook signing secret\n3. Wait for domain verification\n4. Start using Resend for sending emails!\n\n### Note:\nDomain verification typically takes 24-48 hours after adding DNS records."
+      },
+      "id": "note-1",
+      "name": "Sticky Note",
+      "type": "n8n-nodes-base.stickyNote",
+      "typeVersion": 1,
+      "position": [200, 40]
+    }
+  ],
+  "connections": {
+    "Manual Trigger": {
+      "main": [
+        [
+          {
+            "node": "Configuration",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Configuration": {
+      "main": [
+        [
+          {
+            "node": "List Existing Domains",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "List Existing Domains": {
+      "main": [
+        [
+          {
+            "node": "Check Domain Status",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Check Domain Status": {
+      "main": [
+        [
+          {
+            "node": "Domain Exists?",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Domain Exists?": {
+      "main": [
+        [
+          {
+            "node": "Format Domain Info",
+            "type": "main",
+            "index": 0
+          }
+        ],
+        [
+          {
+            "node": "Create Domain",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Create Domain": {
+      "main": [
+        [
+          {
+            "node": "Format Domain Info",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Format Domain Info": {
+      "main": [
+        [
+          {
+            "node": "List Existing Webhooks",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "List Existing Webhooks": {
+      "main": [
+        [
+          {
+            "node": "Check Webhook Status",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Check Webhook Status": {
+      "main": [
+        [
+          {
+            "node": "Webhook Exists?",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Webhook Exists?": {
+      "main": [
+        [
+          {
+            "node": "Generate Setup Report",
+            "type": "main",
+            "index": 0
+          }
+        ],
+        [
+          {
+            "node": "Create Webhook",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Create Webhook": {
+      "main": [
+        [
+          {
+            "node": "Generate Setup Report",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    }
+  },
+  "settings": {
+    "executionOrder": "v1"
+  },
+  "staticData": null,
+  "tags": [],
+  "triggerCount": 1,
+  "pinData": {}
+}

--- a/examples/human-in-loop-approval.json
+++ b/examples/human-in-loop-approval.json
@@ -135,7 +135,7 @@
     {
       "parameters": {
         "mode": "raw",
-        "jsonOutput": "={\n  \"request_id\": \"{{ $('Get Approval Request').item.json.request_id }}\",\n  \"status\": \"{{ $json.data.approved ? 'approved' : 'declined' }}\",\n  \"processed_at\": \"{{ new Date().toISOString() }}\",\n  \"requester\": \"{{ $('Get Approval Request').item.json.requester_name }}\"\n}",
+        "jsonOutput": "={\n  \"request_id\": \"{{ $('Get Approval Request').item.json.request_id }}\",\n  \"status\": \"{{ $('Send Approval Email').item.json.data.approved ? 'approved' : 'declined' }}\",\n  \"processed_at\": \"{{ new Date().toISOString() }}\",\n  \"requester\": \"{{ $('Get Approval Request').item.json.requester_name }}\"\n}",
         "options": {}
       },
       "id": "set-1",

--- a/examples/human-in-loop-approval.json
+++ b/examples/human-in-loop-approval.json
@@ -1,0 +1,241 @@
+{
+  "name": "Resend - Human-in-the-Loop Approval",
+  "nodes": [
+    {
+      "parameters": {},
+      "id": "manual-trigger-1",
+      "name": "Manual Trigger",
+      "type": "n8n-nodes-base.manualTrigger",
+      "typeVersion": 1,
+      "position": [240, 300]
+    },
+    {
+      "parameters": {
+        "jsCode": "// Simulate an approval request - replace with your actual data source\n// This could come from a form, webhook, database, etc.\n\nreturn [{\n  json: {\n    request_id: 'REQ-2024-001',\n    request_type: 'Expense Report',\n    requester_name: 'John Smith',\n    requester_email: 'john.smith@company.com',\n    amount: '$2,450.00',\n    description: 'Q4 Marketing Conference Travel Expenses',\n    submitted_date: new Date().toISOString().split('T')[0],\n    approver_email: 'manager@company.com',  // Change to actual approver email\n    details: [\n      'Flight: $850',\n      'Hotel (3 nights): $1,200',\n      'Meals & Transportation: $400'\n    ]\n  }\n}];"
+      },
+      "id": "code-1",
+      "name": "Get Approval Request",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [440, 300],
+      "notes": "Replace with your data source (form, database, API, etc.)"
+    },
+    {
+      "parameters": {
+        "resource": "email",
+        "operation": "sendAndWait",
+        "sendFrom": "approvals@yourdomain.com",
+        "sendTo": "={{ $json.approver_email }}",
+        "subject": "=Approval Required: {{ $json.request_type }} - {{ $json.request_id }}",
+        "message": "=A new {{ $json.request_type }} requires your approval.\n\n**Request Details:**\n- Request ID: {{ $json.request_id }}\n- Requested By: {{ $json.requester_name }}\n- Amount: {{ $json.amount }}\n- Description: {{ $json.description }}\n- Submitted: {{ $json.submitted_date }}\n\n**Breakdown:**\n{{ $json.details.join('\\n') }}\n\nPlease review and click Approve or Decline below.",
+        "responseType": "approval",
+        "approvalOptions": {
+          "values": {
+            "approvalType": "double",
+            "approveLabel": "Approve",
+            "buttonApprovalStyle": "primary",
+            "disapproveLabel": "Decline",
+            "buttonDisapprovalStyle": "secondary"
+          }
+        },
+        "options": {
+          "limitWaitTime": {
+            "values": {
+              "limitType": "afterTimeInterval",
+              "resumeAmount": 48,
+              "resumeUnit": "hours"
+            }
+          },
+          "appendAttribution": true
+        }
+      },
+      "id": "resend-sendwait-1",
+      "name": "Send Approval Email",
+      "type": "n8n-nodes-resend.resend",
+      "typeVersion": 1,
+      "position": [660, 300],
+      "credentials": {
+        "resendApi": {
+          "id": "",
+          "name": "Resend API"
+        }
+      }
+    },
+    {
+      "parameters": {
+        "conditions": {
+          "options": {
+            "caseSensitive": true,
+            "leftValue": "",
+            "typeValidation": "strict"
+          },
+          "conditions": [
+            {
+              "leftValue": "={{ $json.data.approved }}",
+              "rightValue": true,
+              "operator": {
+                "type": "boolean",
+                "operation": "equals"
+              }
+            }
+          ],
+          "combinator": "and"
+        }
+      },
+      "id": "if-1",
+      "name": "Was Approved?",
+      "type": "n8n-nodes-base.if",
+      "typeVersion": 2,
+      "position": [880, 300]
+    },
+    {
+      "parameters": {
+        "resource": "email",
+        "operation": "send",
+        "fromEmail": "approvals@yourdomain.com",
+        "toEmail": "={{ $('Get Approval Request').item.json.requester_email }}",
+        "subject": "=✅ Approved: {{ $('Get Approval Request').item.json.request_type }} - {{ $('Get Approval Request').item.json.request_id }}",
+        "emailType": "html",
+        "htmlBody": "=<h2>Your Request Has Been Approved!</h2>\n<p>Great news! Your {{ $('Get Approval Request').item.json.request_type }} request has been approved.</p>\n<ul>\n<li><strong>Request ID:</strong> {{ $('Get Approval Request').item.json.request_id }}</li>\n<li><strong>Amount:</strong> {{ $('Get Approval Request').item.json.amount }}</li>\n<li><strong>Approved on:</strong> {{ new Date().toLocaleDateString() }}</li>\n</ul>\n<p>Please proceed with the next steps.</p>"
+      },
+      "id": "resend-approved-1",
+      "name": "Send Approved Notification",
+      "type": "n8n-nodes-resend.resend",
+      "typeVersion": 1,
+      "position": [1120, 180],
+      "credentials": {
+        "resendApi": {
+          "id": "",
+          "name": "Resend API"
+        }
+      }
+    },
+    {
+      "parameters": {
+        "resource": "email",
+        "operation": "send",
+        "fromEmail": "approvals@yourdomain.com",
+        "toEmail": "={{ $('Get Approval Request').item.json.requester_email }}",
+        "subject": "=❌ Declined: {{ $('Get Approval Request').item.json.request_type }} - {{ $('Get Approval Request').item.json.request_id }}",
+        "emailType": "html",
+        "htmlBody": "=<h2>Your Request Has Been Declined</h2>\n<p>Unfortunately, your {{ $('Get Approval Request').item.json.request_type }} request was not approved.</p>\n<ul>\n<li><strong>Request ID:</strong> {{ $('Get Approval Request').item.json.request_id }}</li>\n<li><strong>Amount:</strong> {{ $('Get Approval Request').item.json.amount }}</li>\n<li><strong>Declined on:</strong> {{ new Date().toLocaleDateString() }}</li>\n</ul>\n<p>Please contact your manager for more information.</p>"
+      },
+      "id": "resend-declined-1",
+      "name": "Send Declined Notification",
+      "type": "n8n-nodes-resend.resend",
+      "typeVersion": 1,
+      "position": [1120, 420],
+      "credentials": {
+        "resendApi": {
+          "id": "",
+          "name": "Resend API"
+        }
+      }
+    },
+    {
+      "parameters": {
+        "mode": "raw",
+        "jsonOutput": "={\n  \"request_id\": \"{{ $('Get Approval Request').item.json.request_id }}\",\n  \"status\": \"{{ $json.data.approved ? 'approved' : 'declined' }}\",\n  \"processed_at\": \"{{ new Date().toISOString() }}\",\n  \"requester\": \"{{ $('Get Approval Request').item.json.requester_name }}\"\n}",
+        "options": {}
+      },
+      "id": "set-1",
+      "name": "Update Database",
+      "type": "n8n-nodes-base.set",
+      "typeVersion": 3.3,
+      "position": [1340, 300],
+      "notes": "Replace with actual database update (e.g., Postgres, Airtable)"
+    },
+    {
+      "parameters": {
+        "content": "## Human-in-the-Loop Approval Workflow\n\nThis workflow implements a complete approval process using Resend's Send and Wait functionality.\n\n### How It Works:\n1. **Trigger**: Manual trigger (replace with form, webhook, or schedule)\n2. **Get Request**: Loads the item requiring approval\n3. **Send Approval Email**: Sends email with Approve/Decline buttons\n4. **Wait**: Workflow pauses until recipient clicks a button (or timeout)\n5. **Route**: Routes to approved or declined path\n6. **Notify**: Sends outcome notification to requester\n7. **Update**: Updates database with decision\n\n### Configuration:\n- Set your sender email domain (must be verified in Resend)\n- Configure the timeout (default: 48 hours)\n- Connect to your data source and destination\n- Add Resend API credentials"
+      },
+      "id": "note-1",
+      "name": "Sticky Note",
+      "type": "n8n-nodes-base.stickyNote",
+      "typeVersion": 1,
+      "position": [200, 40]
+    }
+  ],
+  "connections": {
+    "Manual Trigger": {
+      "main": [
+        [
+          {
+            "node": "Get Approval Request",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Get Approval Request": {
+      "main": [
+        [
+          {
+            "node": "Send Approval Email",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Send Approval Email": {
+      "main": [
+        [
+          {
+            "node": "Was Approved?",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Was Approved?": {
+      "main": [
+        [
+          {
+            "node": "Send Approved Notification",
+            "type": "main",
+            "index": 0
+          }
+        ],
+        [
+          {
+            "node": "Send Declined Notification",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Send Approved Notification": {
+      "main": [
+        [
+          {
+            "node": "Update Database",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Send Declined Notification": {
+      "main": [
+        [
+          {
+            "node": "Update Database",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    }
+  },
+  "settings": {
+    "executionOrder": "v1"
+  },
+  "staticData": null,
+  "tags": [],
+  "triggerCount": 1,
+  "pinData": {}
+}

--- a/examples/human-in-loop-freetext.json
+++ b/examples/human-in-loop-freetext.json
@@ -1,0 +1,282 @@
+{
+  "name": "Resend - Human-in-the-Loop Free Text Feedback",
+  "nodes": [
+    {
+      "parameters": {
+        "rule": {
+          "interval": [
+            {
+              "field": "weeks",
+              "weekInterval": 1,
+              "triggerAtDay": [1]
+            }
+          ]
+        }
+      },
+      "id": "schedule-1",
+      "name": "Weekly Schedule",
+      "type": "n8n-nodes-base.scheduleTrigger",
+      "typeVersion": 1.2,
+      "position": [240, 300]
+    },
+    {
+      "parameters": {
+        "operation": "get",
+        "documentId": {
+          "__rl": true,
+          "mode": "list",
+          "value": ""
+        },
+        "sheetName": {
+          "__rl": true,
+          "mode": "list",
+          "value": ""
+        },
+        "filtersUI": {
+          "values": [
+            {
+              "lookupColumn": "status",
+              "lookupValue": "pending_feedback"
+            }
+          ]
+        }
+      },
+      "id": "sheets-1",
+      "name": "Get Pending Feedback Requests",
+      "type": "n8n-nodes-base.googleSheets",
+      "typeVersion": 4.4,
+      "position": [440, 300],
+      "notes": "Configure Google Sheets credentials and document"
+    },
+    {
+      "parameters": {
+        "resource": "email",
+        "operation": "sendAndWait",
+        "sendFrom": "feedback@yourdomain.com",
+        "sendTo": "={{ $json.customer_email }}",
+        "subject": "=We'd love your feedback on {{ $json.product_name }}!",
+        "message": "=Hi {{ $json.customer_name }},\n\nThank you for your recent purchase of {{ $json.product_name }}!\n\nWe'd love to hear your thoughts. Your feedback helps us improve our products and service.\n\n**Order Details:**\n- Order #: {{ $json.order_id }}\n- Product: {{ $json.product_name }}\n- Purchase Date: {{ $json.purchase_date }}\n\nClick the button below to share your experience:",
+        "responseType": "freeText",
+        "options": {
+          "messageButtonLabel": "Share Feedback",
+          "responseFormTitle": "Your Feedback",
+          "responseFormDescription": "=Please share your experience with {{ $json.product_name }}. We read every response!",
+          "responseFormButtonLabel": "Submit Feedback",
+          "limitWaitTime": {
+            "values": {
+              "limitType": "afterTimeInterval",
+              "resumeAmount": 7,
+              "resumeUnit": "days"
+            }
+          },
+          "appendAttribution": true
+        }
+      },
+      "id": "resend-sendwait-1",
+      "name": "Send Feedback Request",
+      "type": "n8n-nodes-resend.resend",
+      "typeVersion": 1,
+      "position": [660, 300],
+      "credentials": {
+        "resendApi": {
+          "id": "",
+          "name": "Resend API"
+        }
+      }
+    },
+    {
+      "parameters": {
+        "conditions": {
+          "options": {
+            "caseSensitive": true,
+            "leftValue": "",
+            "typeValidation": "strict"
+          },
+          "conditions": [
+            {
+              "leftValue": "={{ $json.data.text }}",
+              "rightValue": "",
+              "operator": {
+                "type": "string",
+                "operation": "notEmpty"
+              }
+            }
+          ],
+          "combinator": "and"
+        }
+      },
+      "id": "if-1",
+      "name": "Has Response?",
+      "type": "n8n-nodes-base.if",
+      "typeVersion": 2,
+      "position": [880, 300]
+    },
+    {
+      "parameters": {
+        "jsCode": "// Process and analyze the feedback\nconst feedback = $input.first().json.data.text;\nconst originalData = $('Get Pending Feedback Requests').first().json;\n\n// Simple sentiment analysis based on keywords\nconst positiveWords = ['great', 'excellent', 'amazing', 'love', 'perfect', 'fantastic', 'wonderful', 'happy', 'satisfied'];\nconst negativeWords = ['bad', 'poor', 'terrible', 'hate', 'awful', 'disappointed', 'unhappy', 'broken', 'defective'];\n\nconst lowerFeedback = feedback.toLowerCase();\nlet sentiment = 'neutral';\nlet score = 0;\n\npositiveWords.forEach(word => {\n  if (lowerFeedback.includes(word)) score++;\n});\n\nnegativeWords.forEach(word => {\n  if (lowerFeedback.includes(word)) score--;\n});\n\nif (score > 0) sentiment = 'positive';\nif (score < 0) sentiment = 'negative';\n\nreturn [{\n  json: {\n    order_id: originalData.order_id,\n    customer_email: originalData.customer_email,\n    customer_name: originalData.customer_name,\n    product_name: originalData.product_name,\n    feedback_text: feedback,\n    sentiment: sentiment,\n    sentiment_score: score,\n    received_at: new Date().toISOString(),\n    word_count: feedback.split(' ').length\n  }\n}];"
+      },
+      "id": "code-1",
+      "name": "Analyze Feedback",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [1100, 180]
+    },
+    {
+      "parameters": {
+        "operation": "append",
+        "documentId": {
+          "__rl": true,
+          "mode": "list",
+          "value": ""
+        },
+        "sheetName": {
+          "__rl": true,
+          "mode": "list",
+          "value": ""
+        },
+        "columns": {
+          "mappingMode": "defineBelow",
+          "value": {
+            "order_id": "={{ $json.order_id }}",
+            "customer_email": "={{ $json.customer_email }}",
+            "customer_name": "={{ $json.customer_name }}",
+            "product_name": "={{ $json.product_name }}",
+            "feedback_text": "={{ $json.feedback_text }}",
+            "sentiment": "={{ $json.sentiment }}",
+            "received_at": "={{ $json.received_at }}"
+          }
+        }
+      },
+      "id": "sheets-2",
+      "name": "Save to Feedback Sheet",
+      "type": "n8n-nodes-base.googleSheets",
+      "typeVersion": 4.4,
+      "position": [1320, 180],
+      "notes": "Configure Google Sheets credentials"
+    },
+    {
+      "parameters": {
+        "resource": "email",
+        "operation": "send",
+        "fromEmail": "feedback@yourdomain.com",
+        "toEmail": "={{ $json.customer_email }}",
+        "subject": "Thank you for your feedback!",
+        "emailType": "html",
+        "htmlBody": "=<h2>Thank You, {{ $json.customer_name }}!</h2>\n<p>We really appreciate you taking the time to share your thoughts about {{ $json.product_name }}.</p>\n<p>Your feedback helps us improve and serve you better.</p>\n<p>If you have any other questions or concerns, please don't hesitate to reach out!</p>\n<p>Best regards,<br>The Team</p>"
+      },
+      "id": "resend-thanks-1",
+      "name": "Send Thank You",
+      "type": "n8n-nodes-resend.resend",
+      "typeVersion": 1,
+      "position": [1540, 180],
+      "credentials": {
+        "resendApi": {
+          "id": "",
+          "name": "Resend API"
+        }
+      }
+    },
+    {
+      "parameters": {
+        "jsCode": "// Mark as no response received (timed out)\nconst originalData = $('Get Pending Feedback Requests').first().json;\n\nreturn [{\n  json: {\n    order_id: originalData.order_id,\n    customer_email: originalData.customer_email,\n    status: 'no_response',\n    processed_at: new Date().toISOString()\n  }\n}];"
+      },
+      "id": "code-2",
+      "name": "Mark No Response",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [1100, 420]
+    },
+    {
+      "parameters": {
+        "content": "## Free Text Feedback Collection Workflow\n\nThis workflow collects customer feedback using Resend's Send and Wait with free text response.\n\n### How It Works:\n1. **Schedule**: Runs weekly (configurable)\n2. **Get Requests**: Loads customers pending feedback\n3. **Send Email**: Sends feedback request with form link\n4. **Wait**: Workflow pauses until customer responds (or 7-day timeout)\n5. **Process**: Analyzes feedback sentiment\n6. **Save**: Stores feedback in Google Sheets\n7. **Thank**: Sends thank-you email to customer\n\n### Features:\n- Form-based text input for customers\n- Basic sentiment analysis\n- Automatic thank-you emails\n- Timeout handling for non-responders\n\n### Configuration:\n- Set your verified sender domain\n- Connect Google Sheets for data storage\n- Adjust timeout period as needed"
+      },
+      "id": "note-1",
+      "name": "Sticky Note",
+      "type": "n8n-nodes-base.stickyNote",
+      "typeVersion": 1,
+      "position": [200, 40]
+    }
+  ],
+  "connections": {
+    "Weekly Schedule": {
+      "main": [
+        [
+          {
+            "node": "Get Pending Feedback Requests",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Get Pending Feedback Requests": {
+      "main": [
+        [
+          {
+            "node": "Send Feedback Request",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Send Feedback Request": {
+      "main": [
+        [
+          {
+            "node": "Has Response?",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Has Response?": {
+      "main": [
+        [
+          {
+            "node": "Analyze Feedback",
+            "type": "main",
+            "index": 0
+          }
+        ],
+        [
+          {
+            "node": "Mark No Response",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Analyze Feedback": {
+      "main": [
+        [
+          {
+            "node": "Save to Feedback Sheet",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Save to Feedback Sheet": {
+      "main": [
+        [
+          {
+            "node": "Send Thank You",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    }
+  },
+  "settings": {
+    "executionOrder": "v1"
+  },
+  "staticData": null,
+  "tags": [],
+  "triggerCount": 1,
+  "pinData": {}
+}

--- a/examples/trigger-contact-sync.json
+++ b/examples/trigger-contact-sync.json
@@ -150,7 +150,7 @@
     {
       "parameters": {
         "method": "PUT",
-        "url": "=https://your-crm.com/api/contacts/{{ $json.data.email }}",
+        "url": "=https://your-crm.com/api/contacts/{{ encodeURIComponent($json.data.email) }}",
         "sendHeaders": true,
         "headerParameters": {
           "parameters": [
@@ -196,7 +196,7 @@
     {
       "parameters": {
         "method": "DELETE",
-        "url": "=https://your-crm.com/api/contacts/{{ $json.data.email }}",
+        "url": "=https://your-crm.com/api/contacts/{{ encodeURIComponent($json.data.email) }}",
         "sendHeaders": true,
         "headerParameters": {
           "parameters": [

--- a/examples/trigger-contact-sync.json
+++ b/examples/trigger-contact-sync.json
@@ -1,0 +1,316 @@
+{
+  "name": "Resend - Contact Sync on Events",
+  "nodes": [
+    {
+      "parameters": {
+        "path": "resend-contact-sync",
+        "webhookSigningSecret": "={{ $env.RESEND_WEBHOOK_SECRET }}",
+        "events": [
+          "contact.created",
+          "contact.updated",
+          "contact.deleted"
+        ]
+      },
+      "id": "trigger-1",
+      "name": "Resend Trigger",
+      "type": "n8n-nodes-resend.resendTrigger",
+      "typeVersion": 1,
+      "position": [240, 300],
+      "webhookId": "resend-contact-sync"
+    },
+    {
+      "parameters": {
+        "rules": {
+          "rules": [
+            {
+              "outputKey": "created",
+              "conditions": {
+                "options": {
+                  "caseSensitive": true,
+                  "leftValue": "",
+                  "typeValidation": "strict"
+                },
+                "conditions": [
+                  {
+                    "leftValue": "={{ $json.type }}",
+                    "rightValue": "contact.created",
+                    "operator": {
+                      "type": "string",
+                      "operation": "equals"
+                    }
+                  }
+                ],
+                "combinator": "and"
+              },
+              "renameOutput": true
+            },
+            {
+              "outputKey": "updated",
+              "conditions": {
+                "options": {
+                  "caseSensitive": true,
+                  "leftValue": "",
+                  "typeValidation": "strict"
+                },
+                "conditions": [
+                  {
+                    "leftValue": "={{ $json.type }}",
+                    "rightValue": "contact.updated",
+                    "operator": {
+                      "type": "string",
+                      "operation": "equals"
+                    }
+                  }
+                ],
+                "combinator": "and"
+              },
+              "renameOutput": true
+            },
+            {
+              "outputKey": "deleted",
+              "conditions": {
+                "options": {
+                  "caseSensitive": true,
+                  "leftValue": "",
+                  "typeValidation": "strict"
+                },
+                "conditions": [
+                  {
+                    "leftValue": "={{ $json.type }}",
+                    "rightValue": "contact.deleted",
+                    "operator": {
+                      "type": "string",
+                      "operation": "equals"
+                    }
+                  }
+                ],
+                "combinator": "and"
+              },
+              "renameOutput": true
+            }
+          ]
+        }
+      },
+      "id": "switch-1",
+      "name": "Route by Event Type",
+      "type": "n8n-nodes-base.switch",
+      "typeVersion": 3,
+      "position": [480, 300]
+    },
+    {
+      "parameters": {
+        "method": "POST",
+        "url": "https://your-crm.com/api/contacts",
+        "sendHeaders": true,
+        "headerParameters": {
+          "parameters": [
+            {
+              "name": "Authorization",
+              "value": "Bearer {{ $env.CRM_API_KEY }}"
+            },
+            {
+              "name": "Content-Type",
+              "value": "application/json"
+            }
+          ]
+        },
+        "sendBody": true,
+        "bodyParameters": {
+          "parameters": [
+            {
+              "name": "email",
+              "value": "={{ $json.data.email }}"
+            },
+            {
+              "name": "first_name",
+              "value": "={{ $json.data.first_name }}"
+            },
+            {
+              "name": "last_name",
+              "value": "={{ $json.data.last_name }}"
+            },
+            {
+              "name": "source",
+              "value": "resend"
+            },
+            {
+              "name": "resend_id",
+              "value": "={{ $json.data.id }}"
+            }
+          ]
+        }
+      },
+      "id": "http-create-1",
+      "name": "Create in CRM",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [720, 160],
+      "notes": "Replace with your CRM API endpoint"
+    },
+    {
+      "parameters": {
+        "method": "PUT",
+        "url": "=https://your-crm.com/api/contacts/{{ $json.data.email }}",
+        "sendHeaders": true,
+        "headerParameters": {
+          "parameters": [
+            {
+              "name": "Authorization",
+              "value": "Bearer {{ $env.CRM_API_KEY }}"
+            },
+            {
+              "name": "Content-Type",
+              "value": "application/json"
+            }
+          ]
+        },
+        "sendBody": true,
+        "bodyParameters": {
+          "parameters": [
+            {
+              "name": "first_name",
+              "value": "={{ $json.data.first_name }}"
+            },
+            {
+              "name": "last_name",
+              "value": "={{ $json.data.last_name }}"
+            },
+            {
+              "name": "unsubscribed",
+              "value": "={{ $json.data.unsubscribed }}"
+            },
+            {
+              "name": "updated_at",
+              "value": "={{ $json.created_at }}"
+            }
+          ]
+        }
+      },
+      "id": "http-update-1",
+      "name": "Update in CRM",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [720, 300],
+      "notes": "Replace with your CRM API endpoint"
+    },
+    {
+      "parameters": {
+        "method": "DELETE",
+        "url": "=https://your-crm.com/api/contacts/{{ $json.data.email }}",
+        "sendHeaders": true,
+        "headerParameters": {
+          "parameters": [
+            {
+              "name": "Authorization",
+              "value": "Bearer {{ $env.CRM_API_KEY }}"
+            }
+          ]
+        }
+      },
+      "id": "http-delete-1",
+      "name": "Delete from CRM",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [720, 440],
+      "notes": "Replace with your CRM API endpoint"
+    },
+    {
+      "parameters": {
+        "jsCode": "// Log the sync operation for monitoring\nconst event = $input.first().json;\n\nreturn [{\n  json: {\n    operation: event.type.split('.')[1],\n    email: event.data?.email,\n    timestamp: new Date().toISOString(),\n    success: true,\n    resend_event_id: event.id\n  }\n}];"
+      },
+      "id": "code-1",
+      "name": "Log Sync Operation",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [960, 300]
+    },
+    {
+      "parameters": {
+        "content": "## Contact Sync Workflow\n\nThis workflow synchronizes contact changes from Resend to your CRM or external system in real-time.\n\n### Events Handled:\n- **contact.created** → Creates contact in CRM\n- **contact.updated** → Updates contact in CRM\n- **contact.deleted** → Removes contact from CRM\n\n### Setup:\n1. Configure webhook signing secret from Resend dashboard\n2. Replace HTTP Request URLs with your CRM endpoints\n3. Set up environment variable for CRM_API_KEY\n4. Activate and register webhook URL in Resend"
+      },
+      "id": "note-1",
+      "name": "Sticky Note",
+      "type": "n8n-nodes-base.stickyNote",
+      "typeVersion": 1,
+      "position": [200, 40]
+    }
+  ],
+  "connections": {
+    "Resend Trigger": {
+      "main": [
+        [
+          {
+            "node": "Route by Event Type",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Route by Event Type": {
+      "main": [
+        [
+          {
+            "node": "Create in CRM",
+            "type": "main",
+            "index": 0
+          }
+        ],
+        [
+          {
+            "node": "Update in CRM",
+            "type": "main",
+            "index": 0
+          }
+        ],
+        [
+          {
+            "node": "Delete from CRM",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Create in CRM": {
+      "main": [
+        [
+          {
+            "node": "Log Sync Operation",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Update in CRM": {
+      "main": [
+        [
+          {
+            "node": "Log Sync Operation",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Delete from CRM": {
+      "main": [
+        [
+          {
+            "node": "Log Sync Operation",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    }
+  },
+  "settings": {
+    "executionOrder": "v1"
+  },
+  "staticData": null,
+  "tags": [],
+  "triggerCount": 1,
+  "pinData": {}
+}

--- a/examples/trigger-email-events.json
+++ b/examples/trigger-email-events.json
@@ -157,6 +157,28 @@
                 "combinator": "and"
               },
               "renameOutput": true
+            },
+            {
+              "outputKey": "delivery_delayed",
+              "conditions": {
+                "options": {
+                  "caseSensitive": true,
+                  "leftValue": "",
+                  "typeValidation": "strict"
+                },
+                "conditions": [
+                  {
+                    "leftValue": "={{ $json.type }}",
+                    "rightValue": "email.delivery_delayed",
+                    "operator": {
+                      "type": "string",
+                      "operation": "equals"
+                    }
+                  }
+                ],
+                "combinator": "and"
+              },
+              "renameOutput": true
             }
           ]
         }
@@ -213,6 +235,14 @@
             {
               "leftValue": "={{ $json.type }}",
               "rightValue": "email.bounced",
+              "operator": {
+                "type": "string",
+                "operation": "equals"
+              }
+            },
+            {
+              "leftValue": "={{ $json.type }}",
+              "rightValue": "email.complained",
               "operator": {
                 "type": "string",
                 "operation": "equals"
@@ -290,6 +320,13 @@
         [
           {
             "node": "Log to Google Sheets",
+            "type": "main",
+            "index": 0
+          }
+        ],
+        [
+          {
+            "node": "Is Bounce or Complaint?",
             "type": "main",
             "index": 0
           }

--- a/examples/trigger-email-events.json
+++ b/examples/trigger-email-events.json
@@ -1,0 +1,337 @@
+{
+  "name": "Resend - Email Event Tracking",
+  "nodes": [
+    {
+      "parameters": {
+        "path": "resend-email-events",
+        "webhookSigningSecret": "={{ $env.RESEND_WEBHOOK_SECRET }}",
+        "events": [
+          "email.sent",
+          "email.delivered",
+          "email.opened",
+          "email.clicked",
+          "email.bounced",
+          "email.complained",
+          "email.delivery_delayed"
+        ]
+      },
+      "id": "trigger-1",
+      "name": "Resend Trigger",
+      "type": "n8n-nodes-resend.resendTrigger",
+      "typeVersion": 1,
+      "position": [240, 300],
+      "webhookId": "resend-email-events"
+    },
+    {
+      "parameters": {
+        "rules": {
+          "rules": [
+            {
+              "outputKey": "sent",
+              "conditions": {
+                "options": {
+                  "caseSensitive": true,
+                  "leftValue": "",
+                  "typeValidation": "strict"
+                },
+                "conditions": [
+                  {
+                    "leftValue": "={{ $json.type }}",
+                    "rightValue": "email.sent",
+                    "operator": {
+                      "type": "string",
+                      "operation": "equals"
+                    }
+                  }
+                ],
+                "combinator": "and"
+              },
+              "renameOutput": true
+            },
+            {
+              "outputKey": "delivered",
+              "conditions": {
+                "options": {
+                  "caseSensitive": true,
+                  "leftValue": "",
+                  "typeValidation": "strict"
+                },
+                "conditions": [
+                  {
+                    "leftValue": "={{ $json.type }}",
+                    "rightValue": "email.delivered",
+                    "operator": {
+                      "type": "string",
+                      "operation": "equals"
+                    }
+                  }
+                ],
+                "combinator": "and"
+              },
+              "renameOutput": true
+            },
+            {
+              "outputKey": "opened",
+              "conditions": {
+                "options": {
+                  "caseSensitive": true,
+                  "leftValue": "",
+                  "typeValidation": "strict"
+                },
+                "conditions": [
+                  {
+                    "leftValue": "={{ $json.type }}",
+                    "rightValue": "email.opened",
+                    "operator": {
+                      "type": "string",
+                      "operation": "equals"
+                    }
+                  }
+                ],
+                "combinator": "and"
+              },
+              "renameOutput": true
+            },
+            {
+              "outputKey": "clicked",
+              "conditions": {
+                "options": {
+                  "caseSensitive": true,
+                  "leftValue": "",
+                  "typeValidation": "strict"
+                },
+                "conditions": [
+                  {
+                    "leftValue": "={{ $json.type }}",
+                    "rightValue": "email.clicked",
+                    "operator": {
+                      "type": "string",
+                      "operation": "equals"
+                    }
+                  }
+                ],
+                "combinator": "and"
+              },
+              "renameOutput": true
+            },
+            {
+              "outputKey": "bounced",
+              "conditions": {
+                "options": {
+                  "caseSensitive": true,
+                  "leftValue": "",
+                  "typeValidation": "strict"
+                },
+                "conditions": [
+                  {
+                    "leftValue": "={{ $json.type }}",
+                    "rightValue": "email.bounced",
+                    "operator": {
+                      "type": "string",
+                      "operation": "equals"
+                    }
+                  }
+                ],
+                "combinator": "and"
+              },
+              "renameOutput": true
+            },
+            {
+              "outputKey": "complained",
+              "conditions": {
+                "options": {
+                  "caseSensitive": true,
+                  "leftValue": "",
+                  "typeValidation": "strict"
+                },
+                "conditions": [
+                  {
+                    "leftValue": "={{ $json.type }}",
+                    "rightValue": "email.complained",
+                    "operator": {
+                      "type": "string",
+                      "operation": "equals"
+                    }
+                  }
+                ],
+                "combinator": "and"
+              },
+              "renameOutput": true
+            }
+          ]
+        }
+      },
+      "id": "switch-1",
+      "name": "Route by Event Type",
+      "type": "n8n-nodes-base.switch",
+      "typeVersion": 3,
+      "position": [480, 300]
+    },
+    {
+      "parameters": {
+        "operation": "append",
+        "documentId": {
+          "__rl": true,
+          "mode": "list",
+          "value": ""
+        },
+        "sheetName": {
+          "__rl": true,
+          "mode": "list",
+          "value": ""
+        },
+        "columns": {
+          "mappingMode": "defineBelow",
+          "value": {
+            "event_type": "={{ $json.type }}",
+            "email_id": "={{ $json.data.email_id }}",
+            "to": "={{ $json.data.to }}",
+            "from": "={{ $json.data.from }}",
+            "subject": "={{ $json.data.subject }}",
+            "timestamp": "={{ $json.created_at }}",
+            "click_url": "={{ $json.data.click?.link || '' }}",
+            "bounce_type": "={{ $json.data.bounce?.type || '' }}"
+          }
+        }
+      },
+      "id": "sheets-1",
+      "name": "Log to Google Sheets",
+      "type": "n8n-nodes-base.googleSheets",
+      "typeVersion": 4.4,
+      "position": [720, 160],
+      "notes": "Configure your Google Sheets document ID and sheet name"
+    },
+    {
+      "parameters": {
+        "conditions": {
+          "options": {
+            "caseSensitive": true,
+            "leftValue": "",
+            "typeValidation": "strict"
+          },
+          "conditions": [
+            {
+              "leftValue": "={{ $json.type }}",
+              "rightValue": "email.bounced",
+              "operator": {
+                "type": "string",
+                "operation": "equals"
+              }
+            }
+          ],
+          "combinator": "or"
+        }
+      },
+      "id": "if-1",
+      "name": "Is Bounce or Complaint?",
+      "type": "n8n-nodes-base.if",
+      "typeVersion": 2,
+      "position": [720, 400]
+    },
+    {
+      "parameters": {
+        "channel": "#email-alerts",
+        "text": "⚠️ Email Delivery Issue\n\n*Type:* {{ $json.type }}\n*To:* {{ $json.data.to }}\n*Subject:* {{ $json.data.subject }}\n*Bounce Type:* {{ $json.data.bounce?.type || 'N/A' }}\n*Reason:* {{ $json.data.bounce?.message || $json.data.complaint?.type || 'Unknown' }}",
+        "otherOptions": {}
+      },
+      "id": "slack-1",
+      "name": "Alert on Slack",
+      "type": "n8n-nodes-base.slack",
+      "typeVersion": 2.1,
+      "position": [960, 380],
+      "notes": "Configure Slack credentials and channel"
+    },
+    {
+      "parameters": {
+        "content": "## Email Event Tracking Workflow\n\nThis workflow monitors Resend email events and:\n1. Routes events by type (sent, delivered, opened, clicked, bounced)\n2. Logs all events to Google Sheets for analytics\n3. Sends Slack alerts for bounces and complaints\n\n### Setup Instructions:\n1. Configure Resend Trigger with your webhook signing secret\n2. Set up Google Sheets credentials and document\n3. Add Slack credentials (optional)\n4. Activate workflow and register webhook URL in Resend dashboard"
+      },
+      "id": "note-1",
+      "name": "Sticky Note",
+      "type": "n8n-nodes-base.stickyNote",
+      "typeVersion": 1,
+      "position": [200, 40]
+    }
+  ],
+  "connections": {
+    "Resend Trigger": {
+      "main": [
+        [
+          {
+            "node": "Route by Event Type",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Route by Event Type": {
+      "main": [
+        [
+          {
+            "node": "Log to Google Sheets",
+            "type": "main",
+            "index": 0
+          }
+        ],
+        [
+          {
+            "node": "Log to Google Sheets",
+            "type": "main",
+            "index": 0
+          }
+        ],
+        [
+          {
+            "node": "Log to Google Sheets",
+            "type": "main",
+            "index": 0
+          }
+        ],
+        [
+          {
+            "node": "Log to Google Sheets",
+            "type": "main",
+            "index": 0
+          }
+        ],
+        [
+          {
+            "node": "Is Bounce or Complaint?",
+            "type": "main",
+            "index": 0
+          }
+        ],
+        [
+          {
+            "node": "Is Bounce or Complaint?",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Is Bounce or Complaint?": {
+      "main": [
+        [
+          {
+            "node": "Alert on Slack",
+            "type": "main",
+            "index": 0
+          },
+          {
+            "node": "Log to Google Sheets",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    }
+  },
+  "settings": {
+    "executionOrder": "v1"
+  },
+  "staticData": null,
+  "tags": [],
+  "triggerCount": 1,
+  "pinData": {}
+}


### PR DESCRIPTION
Add a new n8n workflow example (examples/contact-audience-management.json)
that implements a newsletter signup flow using the Resend integration.

Key changes:
- Add a webhook node "Newsletter Signup Webhook" to receive signup POSTs.
- Add a "Validate Signup Data" code node to validate and normalize incoming
  payloads (email normalization, required email check, and default fields).
- Add "Get Audiences" Resend node to list audiences and a "Select Target
  Audience" code node to pick a newsletter/subscribers audience or fall back
  to the first one; fail if no audiences exist.
- Add "Create Contact" Resend node to create a contact in the selected
  audience (continues on failure to avoid blocking the flow).
- Add "Contact Created?" if node to branch based on creation success.
- Add "Get Available Segments" Resend node to list segments for the chosen
  audience.
- Begin adding an email send node to welcome new subscribers (HTML body is
  included but truncated in this diff).

Why:
- Provide a complete example demonstrating contact and audience management
  with Resend in n8n, including validation, audience selection, contact
  creation, conditional branching, and a welcome email to onboard new
  subscribers.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a full set of n8n example workflows for the Resend node, plus a README to help users import, configure, and run them. Also fixes approval result references, HTML/JSON templating, and URL encoding so the examples run correctly end to end.

- **New Features**
  - Contact & Audience Management: Webhook signup → validate → pick audience → create contact → welcome email (contact-audience-management.json).
  - Broadcast Automation: Weekly schedule → select audience/template → create/send broadcast → Slack notify (broadcast-automation.json).
  - Email Event Tracking: Resend trigger → route by event → log to Google Sheets → Slack alerts for issues (trigger-email-events.json).
  - Contact Sync Trigger: Sync contact created/updated/deleted to an external CRM via HTTP (trigger-contact-sync.json).
  - Domain & Webhook Setup: Create/list domains, output DNS records, create/list webhooks, generate setup report (domain-webhook-setup.json).
  - Human-in-the-Loop: Approval flow (Approve/Decline) and free-text feedback collection with timeouts and follow-ups (human-in-loop-approval.json, human-in-loop-freetext.json).
  - README with import methods, credential setup, webhook configuration, and tips (examples/README.md).

<sup>Written for commit 8ad2821bac82aa210b46ee34f809908cfc9d0b8b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

