### PR TITLE
chore(repo): update repository and homepage links to Resend

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 <p align="center">
 	<img alt="NPM Version" src="https://img.shields.io/npm/v/n8n-nodes-resend">
-	<img alt="GitHub License" src="https://img.shields.io/github/license/SilkePilon/n8n-nodes-resend">
+	<img alt="GitHub License" src="https://img.shields.io/github/license/resend/n8n-nodes-resend">
 	<img alt="NPM Downloads" src="https://img.shields.io/npm/dm/n8n-nodes-resend">
 	<img alt="NPM Last Update" src="https://img.shields.io/npm/last-update/n8n-nodes-resend">
 	<img alt="n8n community node" src="https://img.shields.io/badge/n8n-community_node-blue?logo=n8n">
@@ -261,7 +261,7 @@ The **Resend Trigger** node receives webhooks for real-time email events. Signat
 ## Development
 
 ```bash
-git clone https://github.com/SilkePilon/n8n-nodes-resend.git
+git clone https://github.com/resend/n8n-nodes-resend.git
 cd n8n-nodes-resend
 npm install
 npm run build
@@ -279,7 +279,7 @@ Enhanced with contributions from [jannispkz/n8n-nodes-resend-complete](https://g
 ---
 
 <p align="center">
-  <a href="https://github.com/SilkePilon/n8n-nodes-resend">GitHub</a> |
-  <a href="https://github.com/SilkePilon/n8n-nodes-resend/issues">Issues</a> |
+  <a href="https://github.com/resend/n8n-nodes-resend">GitHub</a> |
+  <a href="https://github.com/resend/n8n-nodes-resend/issues">Issues</a> |
   <a href="https://resend.com/docs">Resend Docs</a>
 </p>

--- a/package.json
+++ b/package.json
@@ -15,14 +15,14 @@
     "contacts"
   ],
   "license": "MIT",
-  "homepage": "https://github.com/SilkePilon/n8n-nodes-resend/",
+  "homepage": "https://github.com/resend/n8n-nodes-resend",
   "author": {
-    "name": "SilkePilon",
+    "name": "Resend",
     "email": "silkepilon@users.noreply.github.com"
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/SilkePilon/n8n-nodes-resend.git"
+    "url": "git+https://github.com/resend/n8n-nodes-resend.git"
   },
   "engines": {
     "node": ">=20.15"


### PR DESCRIPTION
Update package metadata and README references to point to the new
organisation repository under "resend" instead of "SilkePilon". Change
package.json homepage, author name, and repository URL to the Resend
GitHub account, and update README badges, clone instructions, and
footer links to use the resend/n8n-nodes-resend URLs.

This ensures official ownership and correct links for users, installs,
and documentation.