### PR TITLE
feat: support resourceLocator template variables

### DIFF
--- a/nodes/Resend/Resend.node.ts
+++ b/nodes/Resend/Resend.node.ts
@@ -38,6 +38,7 @@ import {
 	getReceivedEmailsListSearch,
 	getSegmentsListSearch,
 	getTemplatesListSearch,
+	getTemplateVariablesListSearch,
 	getTopicsListSearch,
 	getWebhooksListSearch,
 } from './methods';
@@ -189,6 +190,7 @@ export class Resend implements INodeType {
 			getReceivedEmails: getReceivedEmailsListSearch,
 			getSegments: getSegmentsListSearch,
 			getTemplates: getTemplatesListSearch,
+			getTemplateVariables: getTemplateVariablesListSearch,
 			getTopics: getTopicsListSearch,
 			getWebhooks: getWebhooksListSearch,
 		},

--- a/nodes/Resend/actions/email/send.operation.ts
+++ b/nodes/Resend/actions/email/send.operation.ts
@@ -144,18 +144,29 @@ export const description: INodeProperties[] = [
 				displayName: 'Variable',
 				values: [
 					{
-						displayName: 'Key Name or ID',
+						displayName: 'Key',
 						name: 'key',
-						type: 'options',
+						type: 'resourceLocator',
+						default: { mode: 'list', value: '' },
 						required: true,
-						default: '',
-						typeOptions: {
-							loadOptionsMethod: 'getTemplateVariables',
-							loadOptionsDependsOn: ['emailTemplateId'],
-							allowCustomValues: true,
-						},
-						description:
-							'Template variable name. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+						description: 'Template variable name. Select from the template or enter a custom key.',
+						modes: [
+							{
+								displayName: 'From List',
+								name: 'list',
+								type: 'list',
+								placeholder: 'Select variable...',
+								typeOptions: {
+									searchListMethod: 'getTemplateVariables',
+								},
+							},
+							{
+								displayName: 'By Key',
+								name: 'id',
+								type: 'string',
+								placeholder: 'Enter variable key...',
+							},
+						],
 					},
 					{
 						displayName: 'Value',

--- a/nodes/Resend/methods/index.ts
+++ b/nodes/Resend/methods/index.ts
@@ -44,9 +44,15 @@ export async function getTemplateVariables(
 			return undefined;
 		}
 	};
-	const getParameterValue = (name: string) => {
+	const getParameterValue = (name: string): string | undefined => {
 		const currentParameters = this.getCurrentNodeParameters();
-		const fromCurrentParameters = getStringValue(currentParameters?.[name]);
+
+		const paramValue = currentParameters?.[name];
+		if (paramValue && typeof paramValue === 'object' && 'value' in paramValue) {
+			return getStringValue((paramValue as { value: unknown }).value);
+		}
+
+		const fromCurrentParameters = getStringValue(paramValue);
 		if (fromCurrentParameters) {
 			return fromCurrentParameters;
 		}
@@ -477,4 +483,27 @@ export async function getWebhooksListSearch(
 	filter?: string,
 ): Promise<INodeListSearchResult> {
 	return wrapForListSearch(this, getWebhooks, filter);
+}
+
+export async function getTemplateVariablesListSearch(
+	this: ILoadOptionsFunctions,
+	filter?: string,
+): Promise<INodeListSearchResult> {
+	const options = await getTemplateVariables.call(this);
+
+	let filteredOptions = options;
+	if (filter) {
+		const filterLower = filter.toLowerCase();
+		filteredOptions = options.filter(option =>
+			option.name.toLowerCase().includes(filterLower) ||
+			option.value.toString().toLowerCase().includes(filterLower)
+		);
+	}
+
+	return {
+		results: filteredOptions.map(option => ({
+			name: option.name,
+			value: option.value,
+		}))
+	};
 }

--- a/nodes/Resend/methods/index.ts
+++ b/nodes/Resend/methods/index.ts
@@ -489,21 +489,5 @@ export async function getTemplateVariablesListSearch(
 	this: ILoadOptionsFunctions,
 	filter?: string,
 ): Promise<INodeListSearchResult> {
-	const options = await getTemplateVariables.call(this);
-
-	let filteredOptions = options;
-	if (filter) {
-		const filterLower = filter.toLowerCase();
-		filteredOptions = options.filter(option =>
-			option.name.toLowerCase().includes(filterLower) ||
-			option.value.toString().toLowerCase().includes(filterLower)
-		);
-	}
-
-	return {
-		results: filteredOptions.map(option => ({
-			name: option.name,
-			value: option.value,
-		}))
-	};
+	return wrapForListSearch(this, getTemplateVariables, filter);
 }

--- a/nodes/Resend/transport/index.ts
+++ b/nodes/Resend/transport/index.ts
@@ -180,19 +180,27 @@ export function parseTemplateVariables(
 
 /**
  * Build template send variables object.
+ * Handles both plain string keys and resourceLocator format keys.
  */
 export function buildTemplateSendVariables(
-	variablesInput: { variables?: Array<{ key: string; value?: unknown }> } | undefined,
+	variablesInput: { variables?: Array<{ key: string | { mode?: string; value?: unknown }; value?: unknown }> } | undefined,
 ): Record<string, unknown> | undefined {
 	if (!variablesInput?.variables?.length) {
 		return undefined;
 	}
 	const variables: Record<string, unknown> = {};
 	for (const variable of variablesInput.variables) {
-		if (!variable.key) {
+		let keyValue: string | undefined;
+		if (typeof variable.key === 'object' && variable.key !== null && 'value' in variable.key) {
+			keyValue = variable.key.value as string;
+		} else if (typeof variable.key === 'string') {
+			keyValue = variable.key;
+		}
+
+		if (!keyValue) {
 			continue;
 		}
-		variables[variable.key] = variable.value ?? '';
+		variables[keyValue] = variable.value ?? '';
 	}
 
 	return Object.keys(variables).length ? variables : undefined;

--- a/nodes/Resend/transport/index.ts
+++ b/nodes/Resend/transport/index.ts
@@ -192,9 +192,18 @@ export function buildTemplateSendVariables(
 	for (const variable of variablesInput.variables) {
 		let keyValue: string | undefined;
 		if (typeof variable.key === 'object' && variable.key !== null && 'value' in variable.key) {
-			keyValue = variable.key.value as string;
+			const extracted = variable.key.value;
+			if (typeof extracted === 'string') {
+				const trimmed = extracted.trim();
+				if (trimmed) {
+					keyValue = trimmed;
+				}
+			}
 		} else if (typeof variable.key === 'string') {
-			keyValue = variable.key;
+			const trimmed = variable.key.trim();
+			if (trimmed) {
+				keyValue = trimmed;
+			}
 		}
 
 		if (!keyValue) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "n8n-nodes-resend",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "description": "Resend integration for n8n with full API coverage: Email, Broadcasts, Templates, Domains, Contacts, Segments, Topics, Webhooks, and more",
   "keywords": [
     "n8n-community-node-package",


### PR DESCRIPTION
Handle template variable keys provided as resourceLocator objects
or plain strings when building send variables. Accept both modes in
the email variable UI and ensure loader search works.

- nodes/Resend/transport/index.ts: parse variable.key when it is an
  object with a value property or a plain string, and use the
  extracted key to build the variables map (fallback to empty string
  for missing values).
- nodes/Resend/actions/email/send.operation.ts: change the Variable
  key field to a resourceLocator control with "From List" and "By
  Key" modes and update descriptions and type options for list
  searching and custom keys.
- nodes/Resend/methods/index.ts: make getParameterValue handle
  resourceLocator-style param objects (read .value) and add a new
  getTemplateVariablesListSearch loader that filters template
  variable options for the resourceLocator list mode.
- nodes/Resend/Resend.node.ts: register the new getTemplateVariables
  list search function.
- package.json: bump version to 2.1.1.

This enables users to select template variables from a searchable
list or enter a custom key while preserving backward compatibility
with string keys.