### PR TITLE
feat(resend): update deps, remove isbot checks, add sleep helper

### DIFF
--- a/nodes/Resend/ResendTrigger.node.ts
+++ b/nodes/Resend/ResendTrigger.node.ts
@@ -194,7 +194,6 @@ export class ResendTrigger implements INodeType {
 					'';
 
 				if (!svixId || !svixTimestamp || !svixSignature) {
-					console.error('Missing required Svix headers for webhook verification');
 					return {
 						workflowData: [[]],
 					};
@@ -210,8 +209,6 @@ export class ResendTrigger implements INodeType {
 					this.getNode(),
 				);
 			} catch (error) {
-				// Signature verification failed
-				console.error('Resend webhook signature verification failed:', error);
 				return {
 					workflowData: [[]],
 				};
@@ -219,8 +216,6 @@ export class ResendTrigger implements INodeType {
 		}
 
 		if (!bodyData || typeof bodyData !== 'object' || !('type' in bodyData)) {
-			// Resend should always send a JSON object with a 'type' field
-			console.warn('Received webhook data that was not in the expected format.');
 			return {
 				workflowData: [[]],
 			};
@@ -233,8 +228,6 @@ export class ResendTrigger implements INodeType {
 				workflowData: [this.helpers.returnJsonArray([bodyData])],
 			};
 		} else {
-			// Event type not subscribed to, log and ignore
-			console.log(`Received event type "${eventType}" but not subscribed, ignoring.`);
 			return {
 				workflowData: [[]],
 			};

--- a/nodes/Resend/transport/index.ts
+++ b/nodes/Resend/transport/index.ts
@@ -4,7 +4,7 @@ import type {
 	IDataObject,
 	INodeExecutionData,
 } from 'n8n-workflow';
-import { NodeOperationError } from 'n8n-workflow';
+import { NodeOperationError, sleep } from 'n8n-workflow';
 
 export const RESEND_API_BASE = 'https://api.resend.com';
 
@@ -78,14 +78,11 @@ export async function requestList(
 			json: true,
 		});
 
-	const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
-
 	const allItems: IDataObject[] = [];
 	let hasMore = true;
 	let isFirstRequest = true;
 
 	while (hasMore) {
-		// Rate limiting: wait 1 second between requests (Resend allows 2 req/sec)
 		if (!isFirstRequest) {
 			await sleep(1000);
 		}

--- a/nodes/Resend/utils/sendAndWait/utils.ts
+++ b/nodes/Resend/utils/sendAndWait/utils.ts
@@ -1,4 +1,3 @@
-import { isbot } from 'isbot';
 import {
 	NodeOperationError,
 	SEND_AND_WAIT_OPERATION,
@@ -422,11 +421,6 @@ export async function sendAndWaitWebhook(this: IWebhookFunctions) {
 	const req = this.getRequestObject();
 
 	const responseType = this.getNodeParameter('responseType', 'approval') as 'approval' | 'freeText';
-
-	if (responseType === 'approval' && isbot(req.headers['user-agent'])) {
-		res.send('');
-		return { noWebhookResponse: true };
-	}
 
 	if (responseType === 'freeText') {
 		if (method === 'GET') {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,16 +1,13 @@
 {
   "name": "n8n-nodes-resend",
-  "version": "2.0.1",
+  "version": "2.1.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "n8n-nodes-resend",
-      "version": "2.0.1",
+      "version": "2.1.5",
       "license": "MIT",
-      "dependencies": {
-        "isbot": "^5.1.34"
-      },
       "devDependencies": {
         "@types/jest": "^30.0.0",
         "@types/node": "^25.2.0",
@@ -20,6 +17,7 @@
         "gulp": "^5.0.0",
         "n8n-workflow": "^2.6.0",
         "prettier": "^3.5.3",
+        "rimraf": "^6.1.2",
         "typescript": "^5.9.3"
       },
       "engines": {
@@ -319,6 +317,29 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/nzakas"
+      }
+    },
+    "node_modules/@isaacs/balanced-match": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@isaacs/balanced-match/-/balanced-match-4.0.1.tgz",
+      "integrity": "sha512-yzMTt9lEb8Gv7zRioUilSglI0c0smZ9k5D65677DLWLtWJaXIS3CqcGyUFByYKlnUj6TkjLVs54fBl6+TiGQDQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/@isaacs/brace-expansion": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/@isaacs/brace-expansion/-/brace-expansion-5.0.1.tgz",
+      "integrity": "sha512-WMz71T1JS624nWj2n2fnYAuPovhv7EUhk69R6i9dsVyzxt5eM3bjwvgk9L+APE1TRscGysAVMANkB0jh0LQZrQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@isaacs/balanced-match": "^4.0.1"
+      },
+      "engines": {
+        "node": "20 || >=22"
       }
     },
     "node_modules/@jest/diff-sequences": {
@@ -2077,6 +2098,24 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/glob": {
+      "version": "13.0.1",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-13.0.1.tgz",
+      "integrity": "sha512-B7U/vJpE3DkJ5WXTgTpTRN63uV42DseiXXKMwG14LQBXmsdeIoHAPbU/MEo6II0k5ED74uc2ZGTC6MwHFQhF6w==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "minimatch": "^10.1.2",
+        "minipass": "^7.1.2",
+        "path-scurry": "^2.0.0"
+      },
+      "engines": {
+        "node": "20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/glob-parent": {
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
@@ -2122,6 +2161,22 @@
       },
       "engines": {
         "node": ">= 10.13.0"
+      }
+    },
+    "node_modules/glob/node_modules/minimatch": {
+      "version": "10.1.2",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.1.2.tgz",
+      "integrity": "sha512-fu656aJ0n2kcXwsnwnv9g24tkU5uSmOlTjd6WyyaKm2Z+h1qmY6bAjrcaIxF/BslFqbZ8UBtbJi7KgQOZD2PTw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "@isaacs/brace-expansion": "^5.0.1"
+      },
+      "engines": {
+        "node": "20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/global-modules": {
@@ -2718,15 +2773,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/isbot": {
-      "version": "5.1.34",
-      "resolved": "https://registry.npmjs.org/isbot/-/isbot-5.1.34.tgz",
-      "integrity": "sha512-aCMIBSKd/XPRYdiCQTLC8QHH4YT8B3JUADu+7COgYIZPvkeoMcUHMRjZLM9/7V8fCj+l7FSREc1lOPNjzogo/A==",
-      "license": "Unlicense",
-      "engines": {
-        "node": ">=18"
-      }
-    },
     "node_modules/isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
@@ -3034,6 +3080,16 @@
         "tslib": "^2.0.3"
       }
     },
+    "node_modules/lru-cache": {
+      "version": "11.2.5",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.5.tgz",
+      "integrity": "sha512-vFrFJkWtJvJnD5hg+hJvVE8Lh/TcMzKnTgCWmtBipwI5yLX/iX+5UB2tfuyODF5E7k9xEzMdYgGqaSb1c0c5Yw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
     "node_modules/luxon": {
       "version": "3.7.2",
       "resolved": "https://registry.npmjs.org/luxon/-/luxon-3.7.2.tgz",
@@ -3127,6 +3183,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/minipass": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.2.tgz",
+      "integrity": "sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
       }
     },
     "node_modules/ms": {
@@ -3351,6 +3417,13 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/package-json-from-dist": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
+      "integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0"
+    },
     "node_modules/parent-module": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
@@ -3448,6 +3521,23 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/path-scurry": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-2.0.1.tgz",
+      "integrity": "sha512-oWyT4gICAu+kaA7QWk/jvCHWarMKNs6pXOGWKDTr7cw4IGcUbW+PeTfbaQiLGheFRpjo6O9J0PmyMfQPjH71oA==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "lru-cache": "^11.0.0",
+        "minipass": "^7.1.2"
+      },
+      "engines": {
+        "node": "20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/picocolors": {
@@ -3736,6 +3826,26 @@
       "engines": {
         "iojs": ">=1.0.0",
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/rimraf": {
+      "version": "6.1.2",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-6.1.2.tgz",
+      "integrity": "sha512-cFCkPslJv7BAXJsYlK1dZsbP8/ZNLkCAQ0bi1hf5EKX2QHegmDFEFA6QhuYJlk7UDdc+02JjO80YSOrWPpw06g==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "glob": "^13.0.0",
+        "package-json-from-dist": "^1.0.1"
+      },
+      "bin": {
+        "rimraf": "dist/esm/bin.mjs"
+      },
+      "engines": {
+        "node": "20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/safe-buffer": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "n8n-nodes-resend",
-  "version": "2.1.1",
+  "version": "2.1.6",
   "description": "Resend integration for n8n with full API coverage: Email, Broadcasts, Templates, Domains, Contacts, Segments, Topics, Webhooks, and more",
   "keywords": [
     "n8n-community-node-package",
@@ -18,7 +18,7 @@
   "homepage": "https://github.com/resend/n8n-nodes-resend",
   "author": {
     "name": "Resend",
-    "email": "silkepilon@users.noreply.github.com"
+    "email": "devsilkepilon@gmail.com"
   },
   "repository": {
     "type": "git",
@@ -29,7 +29,8 @@
   },
   "main": "index.js",
   "scripts": {
-    "build": "tsc && gulp build:icons",
+    "clean": "rimraf dist",
+    "build": "npm run clean && tsc && gulp build:icons",
     "dev": "tsc --watch",
     "format": "prettier nodes credentials --write",
     "lint": "eslint nodes credentials",
@@ -49,9 +50,6 @@
       "dist/nodes/Resend/ResendTrigger.node.js"
     ]
   },
-  "dependencies": {
-    "isbot": "^5.1.34"
-  },
   "devDependencies": {
     "@types/jest": "^30.0.0",
     "@types/node": "^25.2.0",
@@ -61,6 +59,7 @@
     "gulp": "^5.0.0",
     "n8n-workflow": "^2.6.0",
     "prettier": "^3.5.3",
+    "rimraf": "^6.1.2",
     "typescript": "^5.9.3"
   },
   "peerDependencies": {


### PR DESCRIPTION
Update package metadata and build scripts, add rimraf and bump
package versions to 2.1.6/2.1.5 in package.json and package-lock.json.
Include rimraf in devDependencies and add a clean script to ensure a
fresh build.

Simplify webhook handling by removing noisy console logs and the
isbot-based early return in send-and-wait flow so bot user agents no
longer cause silent no-response behavior. This avoids dropping webhook
responses based on user-agent detection.

Use the n8n-workflow provided sleep helper instead of a local helper
in Resend transport, and retain a 1s rate-limit pause between list
requests to respect Resend's rate limits. Update author email to the
dev contact.