### PR TITLE
fix(email): default emailFormat and provide safe defaults

### DIFF
--- a/nodes/Resend/actions/email/send.operation.ts
+++ b/nodes/Resend/actions/email/send.operation.ts
@@ -497,9 +497,10 @@ export async function execute(
 			(requestBody.template as Record<string, unknown>).variables = variables;
 		}
 	} else {
-		const emailFormat = this.getNodeParameter('emailFormat', index) as string;
+		// Default to 'html' if emailFormat wasn't set (e.g., when switching from template mode)
+		const emailFormat = (this.getNodeParameter('emailFormat', index, 'html') as string) || 'html';
 		if (emailFormat === 'html' || emailFormat === 'both') {
-			const html = this.getNodeParameter('html', index) as string;
+			const html = this.getNodeParameter('html', index, '') as string;
 			if (!html) {
 				throw new NodeOperationError(this.getNode(), 'HTML Content is required.', {
 					itemIndex: index,
@@ -508,7 +509,7 @@ export async function execute(
 			requestBody.html = html;
 		}
 		if (emailFormat === 'text' || emailFormat === 'both') {
-			const text = this.getNodeParameter('text', index) as string;
+			const text = this.getNodeParameter('text', index, '') as string;
 			if (!text) {
 				throw new NodeOperationError(this.getNode(), 'Text Content is required.', {
 					itemIndex: index,


### PR DESCRIPTION
When emailFormat is missing (for example after switching from template
mode), default it to 'html' so behavior remains predictable. Also pass
default empty strings when reading html and text parameters so the
code can validate presence and throw clear NodeOperationError messages
instead of returning undefined. This prevents runtime errors and
ensures consistent validation for html/text content.