### PR TITLE
fix: attach pairedItem to API action responses and update badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 	<img alt="GitHub License" src="https://img.shields.io/github/license/resend/n8n-nodes-resend">
 	<img alt="NPM Downloads" src="https://img.shields.io/npm/dm/n8n-nodes-resend">
 	<img alt="NPM Last Update" src="https://img.shields.io/npm/last-update/n8n-nodes-resend">
-	<img alt="n8n community node" src="https://img.shields.io/badge/n8n-community_node-blue?logo=n8n">
+	<img alt="Static Badge" src="https://img.shields.io/badge/n8n-2.6.4-EA4B71?logo=n8n">
 </p>
 
 <p align="center">

--- a/nodes/Resend/actions/broadcast/create.operation.ts
+++ b/nodes/Resend/actions/broadcast/create.operation.ts
@@ -172,5 +172,5 @@ export async function execute(
 
 	const response = await apiRequest.call(this, 'POST', '/broadcasts', body);
 
-	return [{ json: response }];
+	return [{ json: response, pairedItem: { item: index } }];
 }

--- a/nodes/Resend/actions/broadcast/delete.operation.ts
+++ b/nodes/Resend/actions/broadcast/delete.operation.ts
@@ -27,5 +27,5 @@ export async function execute(
 
 	const response = await apiRequest.call(this, 'DELETE', `/broadcasts/${broadcastId}`);
 
-	return [{ json: response }];
+	return [{ json: response, pairedItem: { item: index } }];
 }

--- a/nodes/Resend/actions/broadcast/get.operation.ts
+++ b/nodes/Resend/actions/broadcast/get.operation.ts
@@ -27,5 +27,5 @@ export async function execute(
 
 	const response = await apiRequest.call(this, 'GET', `/broadcasts/${broadcastId}`);
 
-	return [{ json: response }];
+	return [{ json: response, pairedItem: { item: index } }];
 }

--- a/nodes/Resend/actions/broadcast/send.operation.ts
+++ b/nodes/Resend/actions/broadcast/send.operation.ts
@@ -59,5 +59,5 @@ export async function execute(
 
 	const response = await apiRequest.call(this, 'POST', `/broadcasts/${broadcastId}/send`, body);
 
-	return [{ json: response }];
+	return [{ json: response, pairedItem: { item: index } }];
 }

--- a/nodes/Resend/actions/broadcast/update.operation.ts
+++ b/nodes/Resend/actions/broadcast/update.operation.ts
@@ -124,5 +124,5 @@ export async function execute(
 		updateFields,
 	);
 
-	return [{ json: response }];
+	return [{ json: response, pairedItem: { item: index } }];
 }

--- a/nodes/Resend/actions/contact/create.operation.ts
+++ b/nodes/Resend/actions/contact/create.operation.ts
@@ -229,5 +229,5 @@ export async function execute(
 
 	const response = await apiRequest.call(this, 'POST', `/audiences/${encodeURIComponent(audienceId)}/contacts`, body);
 
-	return [{ json: response }];
+	return [{ json: response, pairedItem: { item: index } }];
 }

--- a/nodes/Resend/actions/contact/delete.operation.ts
+++ b/nodes/Resend/actions/contact/delete.operation.ts
@@ -42,5 +42,5 @@ export async function execute(
 
 	const response = await apiRequest.call(this, 'DELETE', `/audiences/${encodeURIComponent(audienceId)}/contacts/${encodeURIComponent(contactIdentifier)}`);
 
-	return [{ json: response }];
+	return [{ json: response, pairedItem: { item: index } }];
 }

--- a/nodes/Resend/actions/contact/get.operation.ts
+++ b/nodes/Resend/actions/contact/get.operation.ts
@@ -42,5 +42,5 @@ export async function execute(
 
 	const response = await apiRequest.call(this, 'GET', `/audiences/${encodeURIComponent(audienceId)}/contacts/${encodeURIComponent(contactIdentifier)}`);
 
-	return [{ json: response }];
+	return [{ json: response, pairedItem: { item: index } }];
 }

--- a/nodes/Resend/actions/contact/update.operation.ts
+++ b/nodes/Resend/actions/contact/update.operation.ts
@@ -181,5 +181,5 @@ export async function execute(
 
 	const response = await apiRequest.call(this, 'PATCH', `/audiences/${encodeURIComponent(audienceId)}/contacts/${encodeURIComponent(identifier)}`, body);
 
-	return [{ json: response }];
+	return [{ json: response, pairedItem: { item: index } }];
 }

--- a/nodes/Resend/actions/contactProperty/create.operation.ts
+++ b/nodes/Resend/actions/contactProperty/create.operation.ts
@@ -67,5 +67,5 @@ export async function execute(
 
 	const response = await apiRequest.call(this, 'POST', '/contact-properties', body);
 
-	return [{ json: response }];
+	return [{ json: response, pairedItem: { item: index } }];
 }

--- a/nodes/Resend/actions/contactProperty/delete.operation.ts
+++ b/nodes/Resend/actions/contactProperty/delete.operation.ts
@@ -31,5 +31,5 @@ export async function execute(
 		`/contact-properties/${contactPropertyId}`,
 	);
 
-	return [{ json: response }];
+	return [{ json: response, pairedItem: { item: index } }];
 }

--- a/nodes/Resend/actions/contactProperty/get.operation.ts
+++ b/nodes/Resend/actions/contactProperty/get.operation.ts
@@ -27,5 +27,5 @@ export async function execute(
 
 	const response = await apiRequest.call(this, 'GET', `/contact-properties/${contactPropertyId}`);
 
-	return [{ json: response }];
+	return [{ json: response, pairedItem: { item: index } }];
 }

--- a/nodes/Resend/actions/contactProperty/update.operation.ts
+++ b/nodes/Resend/actions/contactProperty/update.operation.ts
@@ -58,5 +58,5 @@ export async function execute(
 		updateFields,
 	);
 
-	return [{ json: response }];
+	return [{ json: response, pairedItem: { item: index } }];
 }

--- a/nodes/Resend/actions/domain/create.operation.ts
+++ b/nodes/Resend/actions/domain/create.operation.ts
@@ -87,5 +87,5 @@ export async function execute(
 
 	const response = await apiRequest.call(this, 'POST', '/domains', body);
 
-	return [{ json: response }];
+	return [{ json: response, pairedItem: { item: index } }];
 }

--- a/nodes/Resend/actions/domain/delete.operation.ts
+++ b/nodes/Resend/actions/domain/delete.operation.ts
@@ -27,5 +27,5 @@ export async function execute(
 
 	const response = await apiRequest.call(this, 'DELETE', `/domains/${domainId}`);
 
-	return [{ json: response }];
+	return [{ json: response, pairedItem: { item: index } }];
 }

--- a/nodes/Resend/actions/domain/get.operation.ts
+++ b/nodes/Resend/actions/domain/get.operation.ts
@@ -27,5 +27,5 @@ export async function execute(
 
 	const response = await apiRequest.call(this, 'GET', `/domains/${domainId}`);
 
-	return [{ json: response }];
+	return [{ json: response, pairedItem: { item: index } }];
 }

--- a/nodes/Resend/actions/domain/update.operation.ts
+++ b/nodes/Resend/actions/domain/update.operation.ts
@@ -85,5 +85,5 @@ export async function execute(
 
 	const response = await apiRequest.call(this, 'PATCH', `/domains/${domainId}`, body);
 
-	return [{ json: response }];
+	return [{ json: response, pairedItem: { item: index } }];
 }

--- a/nodes/Resend/actions/domain/verify.operation.ts
+++ b/nodes/Resend/actions/domain/verify.operation.ts
@@ -27,5 +27,5 @@ export async function execute(
 
 	const response = await apiRequest.call(this, 'POST', `/domains/${domainId}/verify`);
 
-	return [{ json: response }];
+	return [{ json: response, pairedItem: { item: index } }];
 }

--- a/nodes/Resend/actions/email/cancel.operation.ts
+++ b/nodes/Resend/actions/email/cancel.operation.ts
@@ -27,5 +27,5 @@ export async function execute(
 
 	const response = await apiRequest.call(this, 'POST', `/emails/${emailId}/cancel`);
 
-	return [{ json: response }];
+	return [{ json: response, pairedItem: { item: index } }];
 }

--- a/nodes/Resend/actions/email/retrieve.operation.ts
+++ b/nodes/Resend/actions/email/retrieve.operation.ts
@@ -27,5 +27,5 @@ export async function execute(
 
 	const response = await apiRequest.call(this, 'GET', `/emails/${emailId}`);
 
-	return [{ json: response }];
+	return [{ json: response, pairedItem: { item: index } }];
 }

--- a/nodes/Resend/actions/email/send.operation.ts
+++ b/nodes/Resend/actions/email/send.operation.ts
@@ -672,5 +672,5 @@ export async function execute(
 		json: true,
 	});
 
-	return [{ json: response }];
+	return [{ json: response, pairedItem: { item: index } }];
 }

--- a/nodes/Resend/actions/email/sendBatch.operation.ts
+++ b/nodes/Resend/actions/email/sendBatch.operation.ts
@@ -604,5 +604,5 @@ export async function execute(
 		json: true,
 	});
 
-	return [{ json: response }];
+	return [{ json: response, pairedItem: { item: index } }];
 }

--- a/nodes/Resend/actions/email/update.operation.ts
+++ b/nodes/Resend/actions/email/update.operation.ts
@@ -48,5 +48,5 @@ export async function execute(
 
 	const response = await apiRequest.call(this, 'PATCH', `/emails/${emailId}`, body);
 
-	return [{ json: response }];
+	return [{ json: response, pairedItem: { item: index } }];
 }

--- a/nodes/Resend/actions/template/create.operation.ts
+++ b/nodes/Resend/actions/template/create.operation.ts
@@ -157,5 +157,5 @@ export async function execute(
 
 	const response = await apiRequest.call(this, 'POST', '/templates', body);
 
-	return [{ json: response }];
+	return [{ json: response, pairedItem: { item: index } }];
 }

--- a/nodes/Resend/actions/template/delete.operation.ts
+++ b/nodes/Resend/actions/template/delete.operation.ts
@@ -27,5 +27,5 @@ export async function execute(
 
 	const response = await apiRequest.call(this, 'DELETE', `/templates/${templateId}`);
 
-	return [{ json: response }];
+	return [{ json: response, pairedItem: { item: index } }];
 }

--- a/nodes/Resend/actions/template/get.operation.ts
+++ b/nodes/Resend/actions/template/get.operation.ts
@@ -27,5 +27,5 @@ export async function execute(
 
 	const response = await apiRequest.call(this, 'GET', `/templates/${templateId}`);
 
-	return [{ json: response }];
+	return [{ json: response, pairedItem: { item: index } }];
 }

--- a/nodes/Resend/actions/template/update.operation.ts
+++ b/nodes/Resend/actions/template/update.operation.ts
@@ -181,5 +181,5 @@ export async function execute(
 
 	const response = await apiRequest.call(this, 'PATCH', `/templates/${templateId}`, body);
 
-	return [{ json: response }];
+	return [{ json: response, pairedItem: { item: index } }];
 }

--- a/nodes/Resend/actions/topic/create.operation.ts
+++ b/nodes/Resend/actions/topic/create.operation.ts
@@ -95,5 +95,5 @@ export async function execute(
 
 	const response = await apiRequest.call(this, 'POST', '/topics', body);
 
-	return [{ json: response }];
+	return [{ json: response, pairedItem: { item: index } }];
 }

--- a/nodes/Resend/actions/topic/delete.operation.ts
+++ b/nodes/Resend/actions/topic/delete.operation.ts
@@ -27,5 +27,5 @@ export async function execute(
 
 	const response = await apiRequest.call(this, 'DELETE', `/topics/${topicId}`);
 
-	return [{ json: response }];
+	return [{ json: response, pairedItem: { item: index } }];
 }

--- a/nodes/Resend/actions/topic/get.operation.ts
+++ b/nodes/Resend/actions/topic/get.operation.ts
@@ -27,5 +27,5 @@ export async function execute(
 
 	const response = await apiRequest.call(this, 'GET', `/topics/${topicId}`);
 
-	return [{ json: response }];
+	return [{ json: response, pairedItem: { item: index } }];
 }

--- a/nodes/Resend/actions/topic/update.operation.ts
+++ b/nodes/Resend/actions/topic/update.operation.ts
@@ -84,5 +84,5 @@ export async function execute(
 
 	const response = await apiRequest.call(this, 'PATCH', `/topics/${topicId}`, body);
 
-	return [{ json: response }];
+	return [{ json: response, pairedItem: { item: index } }];
 }

--- a/nodes/Resend/actions/webhook/create.operation.ts
+++ b/nodes/Resend/actions/webhook/create.operation.ts
@@ -51,5 +51,5 @@ export async function execute(
 
 	const response = await apiRequest.call(this, 'POST', '/webhooks', body);
 
-	return [{ json: response }];
+	return [{ json: response, pairedItem: { item: index } }];
 }

--- a/nodes/Resend/actions/webhook/delete.operation.ts
+++ b/nodes/Resend/actions/webhook/delete.operation.ts
@@ -27,5 +27,5 @@ export async function execute(
 
 	const response = await apiRequest.call(this, 'DELETE', `/webhooks/${webhookId}`);
 
-	return [{ json: response }];
+	return [{ json: response, pairedItem: { item: index } }];
 }

--- a/nodes/Resend/actions/webhook/get.operation.ts
+++ b/nodes/Resend/actions/webhook/get.operation.ts
@@ -27,5 +27,5 @@ export async function execute(
 
 	const response = await apiRequest.call(this, 'GET', `/webhooks/${webhookId}`);
 
-	return [{ json: response }];
+	return [{ json: response, pairedItem: { item: index } }];
 }

--- a/nodes/Resend/actions/webhook/update.operation.ts
+++ b/nodes/Resend/actions/webhook/update.operation.ts
@@ -79,5 +79,5 @@ export async function execute(
 
 	const response = await apiRequest.call(this, 'PATCH', `/webhooks/${webhookId}`, updateFields);
 
-	return [{ json: response }];
+	return [{ json: response, pairedItem: { item: index } }];
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "n8n-nodes-resend",
-  "version": "2.1.6",
+  "version": "2.1.8",
   "description": "Resend integration for n8n with full API coverage: Email, Broadcasts, Templates, Domains, Contacts, Segments, Topics, Webhooks, and more",
   "keywords": [
     "n8n-community-node-package",


### PR DESCRIPTION
Add pairedItem: { item: index } to returned results across Resend
action operations (email, sendBatch, send, template create/update,
domain create/update, webhook create/update/delete, broadcast
create/get/update, contact create/update/delete, contactProperty
create/get/update, topic create/delete). This ensures responses are
paired with their corresponding input items for proper n8n workflow
item mapping and downstream node execution.

Also replace README n8n badge with a static badge showing current
package version/label.