### PR TITLE
feat(resend): unify naming, reshape template variables, and add idempotency

### DIFF
--- a/nodes/Resend/actions/broadcast/create.operation.ts
+++ b/nodes/Resend/actions/broadcast/create.operation.ts
@@ -121,14 +121,14 @@ export const description: INodeProperties[] = [
 				description: 'Plain text version of the email for clients that do not support HTML. If omitted, Resend will auto-generate from the HTML content.',
 			},
 			{
-				displayName: 'Topic',
+				displayName: 'Topic Name or ID',
 				name: 'topicId',
 				type: 'options',
 				default: '',
 				typeOptions: {
 					loadOptionsMethod: 'getTopics',
 				},
-				description: 'Topic to scope the broadcast to',
+				description: 'Topic to scope the broadcast to. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
 			},
 		],
 	},

--- a/nodes/Resend/actions/broadcast/send.operation.ts
+++ b/nodes/Resend/actions/broadcast/send.operation.ts
@@ -32,7 +32,7 @@ export const description: INodeProperties[] = [
 		options: [
 			{
 				displayName: 'Scheduled At',
-				name: 'scheduled_at',
+				name: 'scheduledAt',
 				type: 'string',
 				default: '',
 				placeholder: 'in 1 min',
@@ -48,13 +48,13 @@ export async function execute(
 ): Promise<INodeExecutionData[]> {
 	const broadcastId = resolveDynamicIdValue(this, 'broadcastId', index);
 	const sendOptions = this.getNodeParameter('broadcastSendOptions', index, {}) as {
-		scheduled_at?: string;
+		scheduledAt?: string;
 	};
 
 	const body: IDataObject = {};
 
-	if (sendOptions.scheduled_at) {
-		body.scheduled_at = sendOptions.scheduled_at;
+	if (sendOptions.scheduledAt) {
+		body.scheduledAt = sendOptions.scheduledAt;
 	}
 
 	const response = await apiRequest.call(this, 'POST', `/broadcasts/${encodeURIComponent(broadcastId)}/send`, body);

--- a/nodes/Resend/actions/broadcast/update.operation.ts
+++ b/nodes/Resend/actions/broadcast/update.operation.ts
@@ -74,14 +74,14 @@ export const description: INodeProperties[] = [
 				description: 'Email subject line. Keep concise and compelling to maximize open rates.',
 			},
 			{
-				displayName: 'Target Segment',
+				displayName: 'Target Segment Name or ID',
 				name: 'segmentId',
 				type: 'options',
 				default: '',
 				typeOptions: {
 					loadOptionsMethod: 'getSegments',
 				},
-				description: 'The segment to target. All contacts in this segment will receive the broadcast.',
+				description: 'The segment to target. All contacts in this segment will receive the broadcast. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
 			},
 			{
 				displayName: 'Text Content',
@@ -95,14 +95,14 @@ export const description: INodeProperties[] = [
 				description: 'Plain text version of the email for clients that do not support HTML. If omitted, Resend will auto-generate from HTML.',
 			},
 			{
-				displayName: 'Topic',
+				displayName: 'Topic Name or ID',
 				name: 'topicId',
 				type: 'options',
 				default: '',
 				typeOptions: {
 					loadOptionsMethod: 'getTopics',
 				},
-				description: 'Topic to scope the broadcast to',
+				description: 'Topic to scope the broadcast to. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
 			},
 		],
 	},

--- a/nodes/Resend/actions/contact/create.operation.ts
+++ b/nodes/Resend/actions/contact/create.operation.ts
@@ -92,7 +92,7 @@ export const description: INodeProperties[] = [
 						displayName: 'Segment',
 						values: [
 							{
-								displayName: 'Segment',
+								displayName: 'Segment Name or ID',
 								name: 'id',
 								type: 'options',
 								required: true,
@@ -121,7 +121,7 @@ export const description: INodeProperties[] = [
 						displayName: 'Topic',
 						values: [
 							{
-								displayName: 'Topic',
+								displayName: 'Topic Name or ID',
 								name: 'id',
 								type: 'options',
 								required: true,

--- a/nodes/Resend/actions/contact/updateTopics.operation.ts
+++ b/nodes/Resend/actions/contact/updateTopics.operation.ts
@@ -38,7 +38,7 @@ export const description: INodeProperties[] = [
 				displayName: 'Topic',
 				values: [
 					{
-						displayName: 'Topic',
+						displayName: 'Topic Name or ID',
 						name: 'id',
 						type: 'options',
 						required: true,

--- a/nodes/Resend/actions/contactProperty/create.operation.ts
+++ b/nodes/Resend/actions/contactProperty/create.operation.ts
@@ -62,7 +62,7 @@ export async function execute(
 	const body: IDataObject = { key, type };
 
 	if (fallbackValue) {
-		body.fallback_value = fallbackValue;
+		body.fallbackValue = fallbackValue;
 	}
 
 	const response = await apiRequest.call(this, 'POST', '/contact-properties', body);

--- a/nodes/Resend/actions/contactProperty/update.operation.ts
+++ b/nodes/Resend/actions/contactProperty/update.operation.ts
@@ -32,7 +32,7 @@ export const description: INodeProperties[] = [
 		options: [
 			{
 				displayName: 'Fallback Value',
-				name: 'fallback_value',
+				name: 'fallbackValue',
 				type: 'string',
 				default: '',
 				placeholder: 'Acme Corp',
@@ -48,7 +48,7 @@ export async function execute(
 ): Promise<INodeExecutionData[]> {
 	const contactPropertyId = resolveDynamicIdValue(this, 'contactPropertyId', index);
 	const updateFields = this.getNodeParameter('contactPropertyUpdateFields', index, {}) as {
-		fallback_value?: string;
+		fallbackValue?: string;
 	};
 
 	const response = await apiRequest.call(

--- a/nodes/Resend/actions/domain/create.operation.ts
+++ b/nodes/Resend/actions/domain/create.operation.ts
@@ -43,17 +43,11 @@ export const description: INodeProperties[] = [
 		},
 		options: [
 			{
-				displayName: 'Region',
-				name: 'region',
-				type: 'options',
-				options: [
-					{ name: 'US East 1', value: 'us-east-1' },
-					{ name: 'EU West 1', value: 'eu-west-1' },
-					{ name: 'South America East 1', value: 'sa-east-1' },
-					{ name: 'Asia Pacific Northeast 1', value: 'ap-northeast-1' },
-				],
-				default: 'us-east-1',
-				description: 'The AWS region where emails will be sent from. Choose a region closest to your recipients for better deliverability.',
+				displayName: 'Click Tracking',
+				name: 'clickTracking',
+				type: 'boolean',
+				default: false,
+				description: 'Whether to track clicks within the body of each HTML email sent from this domain',
 			},
 			{
 				displayName: 'Custom Return Path',
@@ -70,11 +64,17 @@ export const description: INodeProperties[] = [
 				description: 'Whether to track the open rate of each email sent from this domain',
 			},
 			{
-				displayName: 'Click Tracking',
-				name: 'clickTracking',
-				type: 'boolean',
-				default: false,
-				description: 'Whether to track clicks within the body of each HTML email sent from this domain',
+				displayName: 'Region',
+				name: 'region',
+				type: 'options',
+				options: [
+					{ name: 'US East 1', value: 'us-east-1' },
+					{ name: 'EU West 1', value: 'eu-west-1' },
+					{ name: 'South America East 1', value: 'sa-east-1' },
+					{ name: 'Asia Pacific Northeast 1', value: 'ap-northeast-1' },
+				],
+				default: 'us-east-1',
+				description: 'The AWS region where emails will be sent from. Choose a region closest to your recipients for better deliverability.',
 			},
 			{
 				displayName: 'TLS',

--- a/nodes/Resend/actions/email/send.operation.ts
+++ b/nodes/Resend/actions/email/send.operation.ts
@@ -364,6 +364,13 @@ export const description: INodeProperties[] = [
 				description: 'Custom email headers to include in the message. Useful for tracking, thread management, or custom metadata.',
 			},
 			{
+				displayName: 'Idempotency Key',
+				name: 'idempotencyKey',
+				type: 'string',
+				default: '',
+				description: 'A unique key to ensure the email is sent only once. Useful for retries to prevent duplicate sends.',
+			},
+			{
 				displayName: 'Reply To',
 				name: 'replyTo',
 				type: 'string',
@@ -410,21 +417,14 @@ export const description: INodeProperties[] = [
 				description: 'Key-value tags to categorize and track emails. Useful for analytics and filtering. Example: name="campaign", value="welcome-series".',
 			},
 			{
-				displayName: 'Topic',
+				displayName: 'Topic Name or ID',
 				name: 'topicId',
 				type: 'options',
 				default: '',
 				typeOptions: {
 					loadOptionsMethod: 'getTopics',
 				},
-				description: 'Associate this email with a specific subscription topic. Used for managing email preferences and unsubscribe handling.',
-			},
-			{
-				displayName: 'Idempotency Key',
-				name: 'idempotencyKey',
-				type: 'string',
-				default: '',
-				description: 'A unique key to ensure the email is sent only once. Useful for retries to prevent duplicate sends.',
+				description: 'Associate this email with a specific subscription topic. Used for managing email preferences and unsubscribe handling. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
 			},
 		],
 	},

--- a/nodes/Resend/actions/email/sendBatch.operation.ts
+++ b/nodes/Resend/actions/email/sendBatch.operation.ts
@@ -110,14 +110,14 @@ export const description: INodeProperties[] = [
 								description: 'Key-value tags for email categorization and analytics. Use for tracking campaigns or custom metadata.',
 							},
 							{
-								displayName: 'Topic',
+								displayName: 'Topic Name or ID',
 								name: 'topicId',
 								type: 'options',
 								default: '',
 								typeOptions: {
 									loadOptionsMethod: 'getTopics',
 								},
-								description: 'Topic to scope this email to for subscription preference management.',
+								description: 'Topic to scope this email to for subscription preference management. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
 							},
 					]
 					},

--- a/nodes/Resend/actions/email/update.operation.ts
+++ b/nodes/Resend/actions/email/update.operation.ts
@@ -19,7 +19,7 @@ export const description: INodeProperties[] = [
 	}),
 	{
 		displayName: 'Scheduled At',
-		name: 'scheduled_at',
+		name: 'scheduledAt',
 		type: 'string',
 		default: '',
 		placeholder: '2024-08-05T11:52:01.858Z',
@@ -39,11 +39,11 @@ export async function execute(
 	index: number,
 ): Promise<INodeExecutionData[]> {
 	const emailId = resolveDynamicIdValue(this, 'emailId', index);
-	const scheduledAt = this.getNodeParameter('scheduled_at', index) as string;
+	const scheduledAt = this.getNodeParameter('scheduledAt', index) as string;
 
 	const body: IDataObject = {};
 	if (scheduledAt) {
-		body.scheduled_at = scheduledAt;
+		body.scheduledAt = scheduledAt;
 	}
 
 	const response = await apiRequest.call(this, 'PATCH', `/emails/${encodeURIComponent(emailId)}`, body);

--- a/nodes/Resend/actions/segment/create.operation.ts
+++ b/nodes/Resend/actions/segment/create.operation.ts
@@ -5,23 +5,8 @@ import type {
 	IDataObject,
 } from 'n8n-workflow';
 import { apiRequest } from '../../transport';
-import { createDynamicIdField, resolveDynamicIdValue } from '../../utils/dynamicFields';
 
 export const description: INodeProperties[] = [
-	createDynamicIdField({
-		fieldName: 'audienceId',
-		resourceName: 'audience',
-		displayName: 'Target Audience',
-		required: true,
-		placeholder: 'aud_123456',
-		description: 'The audience this segment will belong to. Segments allow you to group contacts within an audience.',
-		displayOptions: {
-			show: {
-				resource: ['segments'],
-				operation: ['create'],
-			},
-		},
-	}),
 	{
 		displayName: 'Segment Name',
 		name: 'segmentName',
@@ -56,13 +41,11 @@ export async function execute(
 	this: IExecuteFunctions,
 	index: number,
 ): Promise<INodeExecutionData[]> {
-	const audienceId = resolveDynamicIdValue(this, 'audienceId', index);
 	const segmentName = this.getNodeParameter('segmentName', index) as string;
 	const filterInput = this.getNodeParameter('segmentFilter', index, '') as string | IDataObject;
 
 	const body: IDataObject = {
 		name: segmentName,
-		audience_id: audienceId,
 	};
 
 	if (filterInput) {

--- a/nodes/Resend/actions/template/create.operation.ts
+++ b/nodes/Resend/actions/template/create.operation.ts
@@ -145,14 +145,13 @@ export async function execute(
 	};
 
 	if (templateVariables.variables && templateVariables.variables.length > 0) {
-		const variables: Record<string, { type: string; fallback_value?: string }> = {};
-		for (const v of templateVariables.variables) {
-			variables[v.key] = { type: v.type };
+		body.variables = templateVariables.variables.map((v) => {
+			const variable: Record<string, unknown> = { key: v.key, type: v.type };
 			if (v.fallbackValue) {
-				variables[v.key].fallback_value = v.fallbackValue;
+				variable.fallbackValue = v.fallbackValue;
 			}
-		}
-		body.variables = variables;
+			return variable;
+		});
 	}
 
 	const response = await apiRequest.call(this, 'POST', '/templates', body);

--- a/nodes/Resend/actions/template/update.operation.ts
+++ b/nodes/Resend/actions/template/update.operation.ts
@@ -64,7 +64,7 @@ export const description: INodeProperties[] = [
 			},
 			{
 				displayName: 'Reply To',
-				name: 'reply_to',
+				name: 'replyTo',
 				type: 'string',
 				default: '',
 				description: 'Reply-to email address. For multiple addresses, use comma-separated values.',
@@ -158,7 +158,7 @@ export async function execute(
 		from?: string;
 		html?: string;
 		name?: string;
-		reply_to?: string;
+		replyTo?: string;
 		subject?: string;
 		text?: string;
 	};
@@ -169,14 +169,13 @@ export async function execute(
 	const body: IDataObject = { ...updateFields };
 
 	if (templateVariables.variables && templateVariables.variables.length > 0) {
-		const variables: Record<string, { type: string; fallback_value?: string }> = {};
-		for (const v of templateVariables.variables) {
-			variables[v.key] = { type: v.type };
+		body.variables = templateVariables.variables.map((v) => {
+			const variable: Record<string, unknown> = { key: v.key, type: v.type };
 			if (v.fallbackValue) {
-				variables[v.key].fallback_value = v.fallbackValue;
+				variable.fallbackValue = v.fallbackValue;
 			}
-		}
-		body.variables = variables;
+			return variable;
+		});
 	}
 
 	const response = await apiRequest.call(this, 'PATCH', `/templates/${encodeURIComponent(templateId)}`, body);

--- a/nodes/Resend/actions/topic/create.operation.ts
+++ b/nodes/Resend/actions/topic/create.operation.ts
@@ -83,7 +83,7 @@ export async function execute(
 
 	const body: IDataObject = {
 		name,
-		default_subscription: defaultSubscription,
+		defaultSubscription,
 	};
 
 	if (createOptions.description) {

--- a/nodes/Resend/utils/sendAndWait/utils.ts
+++ b/nodes/Resend/utils/sendAndWait/utils.ts
@@ -671,7 +671,7 @@ export async function sendResendEmail(context: IExecuteFunctions, email: IEmail)
 	}
 
 	if (email.replyTo) {
-		requestBody.reply_to = email.replyTo;
+		requestBody.replyTo = email.replyTo;
 	}
 
 	await context.helpers.httpRequestWithAuthentication.call(context, 'resendApi', {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "n8n-nodes-resend",
-  "version": "2.2.0",
+  "version": "2.2.1",
   "description": "Resend integration for n8n with full API coverage: Email, Broadcasts, Templates, Domains, Contacts, Segments, Topics, Webhooks, and more",
   "keywords": [
     "n8n-community-node-package",


### PR DESCRIPTION
- Convert template variable payload to an array of objects instead of a
  keyed record, returning { key, type, fallbackValue } for each variable.
  This matches the client-side parameter naming and simplifies building
  the request body sent to the /templates endpoint.

- Normalize field names from snake_case to camelCase across UI and
  handlers:
  - contactProperty update option and parameter use fallbackValue
    (instead of fallback_value).
  - domain and email fields use clickTracking and idempotencyKey names.
  - ensure replyTo maps consistently when building request bodies.

- Reorder domain options to present Click Tracking before Region and
  adjust descriptions to reflect correct semantics.

- Clarify topic selector labels to "Topic Name or ID" and enhance the
  topic description to allow expressions for IDs.

These changes standardize naming conventions, improve API payload
consistency, and add an idempotency key option to prevent duplicate sends.