### PR TITLE
chore(issues): add detailed GitHub issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,137 @@
+name: 🐛 Bug Report
+description: Report a bug or unexpected behavior with n8n-nodes-resend.
+title: "[Bug]: "
+labels: ["bug", "triage"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to report a bug! Please fill out the form below to help us investigate and fix the issue.
+
+        > **Before opening a new issue**, please [search existing issues](https://github.com/resend/n8n-nodes-resend/issues) to avoid duplicates.
+
+  - type: checkboxes
+    id: existing-issue
+    attributes:
+      label: Pre-flight checklist
+      description: Please confirm the following before submitting.
+      options:
+        - label: I have searched the [existing issues](https://github.com/resend/n8n-nodes-resend/issues) and this bug has not been reported yet.
+          required: true
+        - label: I am using the latest version of `n8n-nodes-resend`.
+          required: false
+        - label: I have read the [README](https://github.com/resend/n8n-nodes-resend#readme) and followed the setup instructions.
+          required: false
+
+  - type: dropdown
+    id: resource
+    attributes:
+      label: Which resource is affected?
+      description: Select the Resend resource where you're experiencing the issue.
+      multiple: true
+      options:
+        - Email
+        - Broadcast
+        - Contact
+        - Contact Property
+        - Domain
+        - Segment
+        - Template
+        - Topic
+        - Webhook
+        - Receiving Email
+        - Trigger Node
+        - Not sure / Other
+    validations:
+      required: true
+
+  - type: dropdown
+    id: severity
+    attributes:
+      label: Severity
+      description: How severe is this bug for your use case?
+      options:
+        - "Critical — Blocks all usage, no workaround"
+        - "Major — Significant feature broken, workaround exists"
+        - "Minor — Small issue, easy to work around"
+        - "Cosmetic — Visual or text issue only"
+    validations:
+      required: true
+
+  - type: textarea
+    id: description
+    attributes:
+      label: Describe the bug
+      description: A clear and concise description of what the bug is.
+      placeholder: Tell us what happened...
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+      description: What did you expect to happen?
+      placeholder: I expected...
+    validations:
+      required: true
+
+  - type: textarea
+    id: steps
+    attributes:
+      label: Steps to reproduce
+      description: Provide detailed steps to reproduce the issue.
+      placeholder: |
+        1. Create a new workflow in n8n
+        2. Add the Resend node
+        3. Select resource '...' and operation '...'
+        4. Configure with the following settings: ...
+        5. Execute the node
+        6. Observe error: ...
+    validations:
+      required: true
+
+  - type: textarea
+    id: environment
+    attributes:
+      label: Environment
+      description: Please provide your environment details.
+      value: |
+        - **n8n version**:
+        - **n8n-nodes-resend version**:
+        - **Node.js version**:
+        - **OS**:
+        - **Deployment method** (Docker / npm / Desktop):
+    validations:
+      required: true
+
+  - type: textarea
+    id: logs
+    attributes:
+      label: Relevant log output / error messages
+      description: |
+        Please copy and paste any relevant log output or error messages.
+        This will be automatically formatted into code, so no need for backticks.
+      render: shell
+    validations:
+      required: false
+
+  - type: textarea
+    id: screenshots
+    attributes:
+      label: Screenshots / Workflow JSON
+      description: |
+        If applicable, add screenshots of the issue or paste your workflow JSON export.
+        You can drag and drop images here, or paste a JSON code block.
+      placeholder: Drag and drop screenshots here, or paste your exported workflow JSON...
+    validations:
+      required: false
+
+  - type: textarea
+    id: additional
+    attributes:
+      label: Additional context
+      description: Any other context about the problem — workarounds you've tried, related issues, etc.
+      placeholder: Add any other context here...
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,11 @@
+blank_issues_enabled: false
+contact_links:
+  - name: ❓ Ask a Question
+    url: https://community.n8n.io/
+    about: Ask questions and get help from the n8n community.
+  - name: 📖 Resend API Documentation
+    url: https://resend.com/docs/introduction
+    about: Check the official Resend API docs for API-related questions.
+  - name: 🔒 Report a Security Vulnerability
+    url: https://github.com/resend/n8n-nodes-resend/security/policy
+    about: Please report security vulnerabilities responsibly.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,126 @@
+name: 💡 Feature Request
+description: Suggest a new feature or enhancement for n8n-nodes-resend.
+title: "[Feature]: "
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for suggesting a feature! Your ideas help make this project better for everyone.
+
+        > **Before opening a new request**, please [search existing issues](https://github.com/resend/n8n-nodes-resend/issues?q=label%3Aenhancement) to check if someone has already suggested it. If so, give it a 👍 to show your support!
+
+  - type: checkboxes
+    id: existing-request
+    attributes:
+      label: Pre-flight checklist
+      description: Please confirm the following before submitting.
+      options:
+        - label: I have searched the [existing feature requests](https://github.com/resend/n8n-nodes-resend/issues?q=label%3Aenhancement) and this has not been suggested yet.
+          required: true
+        - label: I am using the latest version of `n8n-nodes-resend`.
+          required: false
+
+  - type: dropdown
+    id: feature-area
+    attributes:
+      label: Feature area
+      description: Which area does this feature relate to?
+      multiple: true
+      options:
+        - Email
+        - Broadcast
+        - Contact
+        - Contact Property
+        - Domain
+        - Segment
+        - Template
+        - Topic
+        - Webhook
+        - Receiving Email
+        - Trigger Node
+        - New Resource / API endpoint
+        - Developer Experience (DX)
+        - Documentation
+        - Other
+    validations:
+      required: true
+
+  - type: dropdown
+    id: request-type
+    attributes:
+      label: Type of request
+      description: What kind of feature are you requesting?
+      options:
+        - "New feature — Something that doesn't exist yet"
+        - "Enhancement — Improve an existing feature"
+        - "New API coverage — Support a new Resend API endpoint"
+        - "UX improvement — Better defaults, labels, or descriptions"
+    validations:
+      required: true
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem statement
+      description: |
+        Is your feature request related to a problem? Please describe.
+        A clear and concise description of what the problem is.
+      placeholder: "I'm always frustrated when..."
+    validations:
+      required: true
+
+  - type: textarea
+    id: solution
+    attributes:
+      label: Proposed solution
+      description: Describe the solution you'd like. Be as specific as possible.
+      placeholder: |
+        I'd like the node to...
+
+        For example:
+        - Add a new operation "X" under the "Email" resource
+        - Support the `replyTo` field as an optional parameter
+        - Show a dropdown of domains fetched from the Resend API
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Have you considered any alternative solutions or workarounds?
+      placeholder: |
+        I've tried working around this by...
+    validations:
+      required: false
+
+  - type: dropdown
+    id: importance
+    attributes:
+      label: How important is this feature to you?
+      options:
+        - "Nice to have — Would improve my experience"
+        - "Important — I need this for my project"
+        - "Critical — Blocking my adoption / workflow"
+    validations:
+      required: true
+
+  - type: textarea
+    id: api-reference
+    attributes:
+      label: Resend API reference
+      description: |
+        If this relates to a specific Resend API endpoint, please link to the relevant documentation.
+      placeholder: "https://resend.com/docs/api-reference/..."
+    validations:
+      required: false
+
+  - type: textarea
+    id: additional
+    attributes:
+      label: Additional context
+      description: Add any other context, mockups, screenshots, or workflow examples about the feature request.
+      placeholder: Add any other context here...
+    validations:
+      required: false


### PR DESCRIPTION
Add ISSUE_TEMPLATE config and a comprehensive bug_report template to
standardize bug reporting for the n8n-nodes-resend repository.

Key changes:
- Disable blank issues and add contact links for community help,
  Resend docs, and security reporting.
- Add a Bug Report template with guided fields: pre-flight checklist,
  affected resource, severity, description, expected behavior, steps to
  reproduce, environment, logs, screenshots/workflow JSON, and additional
  context. Fields include validations and helpful placeholders to
  improve report quality and triage speed.

Why:
- Improve the clarity and completeness of incoming bug reports.
- Reduce duplicate and low-quality issues by guiding reporters to
  provide necessary details up front, speeding up diagnosis and fixes.