### PR TITLE
docs: warn that Audiences are deprecated in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,9 @@ A community node for [n8n](https://n8n.io) that integrates with the [Resend](htt
 
 ## API Coverage
 
+> [!WARNING]
+> Audiences are deprecated in favor of Segments and won't be supported in this node. Please use Segments for contact grouping and targeting.
+
 Comprehensive coverage of the Resend API (v1.1.0). The table below shows which endpoints are currently implemented:
 
 | API Resource           | Endpoint              | Status  | Operations                                                                                                       |


### PR DESCRIPTION
Update README to add a prominent warning that Audiences are
deprecated and replaced by Segments. Advise users to use Segments
for contact grouping and targeting, and clarify that Audiences
won't be supported in this node. This prevents confusion and
guides users toward the supported feature set.