### PR TITLE
feat: bump version and expand trigger event list

### DIFF
--- a/README.md
+++ b/README.md
@@ -238,21 +238,25 @@ The **Resend Trigger** node receives webhooks for real-time email events. Signat
 
 > **Note:** The trigger node requires the **Resend Webhook Signing Secret** credential (separate from the Resend API credential). See the [Credentials](#credentials) section for setup instructions.
 
-| Event                    | Description                  |
-| ------------------------ | ---------------------------- |
-| `email.sent`             | Email sent to recipient      |
-| `email.delivered`        | Email delivered successfully |
-| `email.delivery_delayed` | Email delivery delayed       |
-| `email.opened`           | Recipient opened the email   |
-| `email.clicked`          | Link clicked in email        |
-| `email.bounced`          | Email bounced                |
-| `email.complained`       | Spam complaint received      |
-| `contact.created`        | New contact added            |
-| `contact.updated`        | Contact modified             |
-| `contact.deleted`        | Contact removed              |
-| `domain.created`         | New domain added             |
-| `domain.updated`         | Domain modified              |
-| `domain.deleted`         | Domain removed               |
+| Event                    | Description                          |
+| ------------------------ | ------------------------------------ |
+| `email.sent`             | Email sent to recipient              |
+| `email.delivered`        | Email delivered successfully         |
+| `email.delivery_delayed` | Email delivery delayed               |
+| `email.opened`           | Recipient opened the email           |
+| `email.clicked`          | Link clicked in email                |
+| `email.bounced`          | Email bounced                        |
+| `email.complained`       | Spam complaint received              |
+| `email.failed`           | Email failed to send due to an error |
+| `email.received`         | Inbound email received by Resend     |
+| `email.scheduled`        | Email scheduled to be sent           |
+| `email.suppressed`       | Email suppressed by Resend           |
+| `contact.created`        | New contact added                    |
+| `contact.updated`        | Contact modified                     |
+| `contact.deleted`        | Contact removed                      |
+| `domain.created`         | New domain added                     |
+| `domain.updated`         | Domain modified                      |
+| `domain.deleted`         | Domain removed                       |
 
 ## Limitations
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "n8n-nodes-resend",
-  "version": "2.3.1",
+  "version": "2.3.2",
   "description": "Resend integration for n8n with full API coverage: Email, Broadcasts, Templates, Domains, Contacts, Segments, Topics, Webhooks, and more",
   "keywords": [
     "n8n-community-node-package",


### PR DESCRIPTION
Bump package version to 2.3.2 and expand README trigger event
table for the Resend webhook integration. Add several new
email events (failed, received, scheduled, suppressed) and
improve table column widths for consistent formatting. These
changes document additional webhook event types supported by
the integration and ensure the README accurately reflects the
trigger node behavior and available events.