### PR TITLE
add trusted published github action

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,32 @@
+name: Publish
+
+on:
+  push:
+    tags:
+      - '*.*.*'
+
+jobs:
+  publish:
+    name: Publish to npm
+    runs-on: ubuntu-latest
+    if: github.event.base_ref == 'refs/heads/master'
+
+    permissions:
+      id-token: write
+      contents: read
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 'lts/*'
+          cache: 'npm'
+          registry-url: 'https://registry.npmjs.org'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Publish
+        run: npm run release

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -3,7 +3,7 @@ name: Publish
 on:
   push:
     tags:
-      - '*.*.*'
+      - 'v*.*.*'
 
 jobs:
   publish:
@@ -29,4 +29,4 @@ jobs:
         run: npm ci
 
       - name: Publish
-        run: npm run release
+        run: npm publish --provenance

--- a/package.json
+++ b/package.json
@@ -34,7 +34,8 @@
 		"format": "prettier nodes credentials --write",
 		"lint": "eslint nodes credentials",
 		"lintfix": "eslint nodes credentials --fix",
-		"prepublishOnly": "npm run build && npm run lint"
+		"prepublishOnly": "npm run build && npm run lint",
+		"release": "npm publish --provenance"
 	},
 	"files": [
 		"dist"

--- a/package.json
+++ b/package.json
@@ -34,8 +34,7 @@
 		"format": "prettier nodes credentials --write",
 		"lint": "eslint nodes credentials",
 		"lintfix": "eslint nodes credentials --fix",
-		"prepublishOnly": "npm run build && npm run lint",
-		"release": "npm publish --provenance"
+		"prepublishOnly": "npm run build && npm run lint"
 	},
 	"files": [
 		"dist"


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Add a trusted publish workflow that releases packages to `npm` on `v*.*.*` tags with provenance via GitHub OIDC. Publishes only for tags created from `master`, removing long‑lived tokens.

- **New Features**
  - Uses `actions/checkout@v4` and `actions/setup-node@v4` (LTS) with `npm` cache and `registry-url` set to `https://registry.npmjs.org`; grants `id-token: write` and `contents: read`.
  - Runs `npm ci` then `npm publish --provenance` (relies on `prepublishOnly` to build/lint if present).

<sup>Written for commit 49294292cbc000e14501c14039c3314538ba8826. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

