### PR TITLE
chore(ci): harden security

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,24 +1,35 @@
 name: Publish
 
+permissions:
+  contents: read
+
 on:
   release:
     types: [published]
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name == 'release' && github.event.release.tag_name || github.sha }}
+  cancel-in-progress: false
+
 jobs:
   publish:
     name: Publish to npm
     runs-on: ubuntu-latest
+    environment: npm-publish
+    timeout-minutes: 30
 
     permissions:
       id-token: write
       contents: read
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          ref: ${{ github.event_name == 'release' && github.event.release.tag_name || github.sha }}
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: "lts/*"
           cache: "npm"


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Hardened the `publish.yml` workflow for `n8n-nodes-resend` with least-privilege, concurrency, environment gating, timeouts, and pinned actions. Reduces release risk and aligns with DEV-651 (0 HIGH / 4 MED / 1 LOW).

- **Refactors**
  - Set top-level permissions to `contents: read`.
  - Added concurrency group keyed by workflow + release tag/SHAs; no cancel-in-progress.
  - Required `environment: npm-publish` for publishes.
  - Added `timeout-minutes: 30` to the publish job.
  - Pinned `actions/checkout` and `actions/setup-node` to SHAs and checked out the release tag or commit SHA.

<sup>Written for commit 991aba8232f00b6bdb4569a7a7792dfd4a263565. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

