### PR TITLE
chore: remove npm token

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -46,5 +46,3 @@ jobs:
 
       - name: Publish to npm with provenance
         run: npm publish --provenance --access public
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
this should work without that, as per we have in other projects:
- https://github.com/resend/react-email/blob/80905f69dadbb991d6299ead218488030bdff28e/.github/workflows/release.yml#L30-L33
- https://github.com/resend/resend-cli/blob/40f0bed325e3ac594c4c781b9aadbab64e5e1a74/.github/workflows/release.yml#L273-L276
- https://github.com/resend/resend-mcp/blob/eabe9d80e7adaeca0eef20de7ad055406ffa7b30/.github/workflows/release.yml#L80-L81


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed `NODE_AUTH_TOKEN` from `.github/workflows/publish.yml` to rely on `npm` Trusted Publishing with provenance, eliminating the need for the `NPM_TOKEN` secret.

<sup>Written for commit 6a2aae75bcfa0eda206367b7485de9a95d7f46fd. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

