### PR TITLE
feat: add domain claim operations and update dependencies

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://biomejs.dev/schemas/2.4.15/schema.json",
+  "$schema": "https://biomejs.dev/schemas/2.5.3/schema.json",
   "files": {
     "includes": ["**", "!**/node_modules", "!**/dist", "!**/_audit"]
   },

--- a/nodes/Resend/actions/domain/claim.operation.ts
+++ b/nodes/Resend/actions/domain/claim.operation.ts
@@ -3,95 +3,95 @@ import type {
   IExecuteFunctions,
   INodeExecutionData,
   INodeProperties,
-} from 'n8n-workflow';
-import { apiRequest } from '../../transport';
+} from "n8n-workflow";
+import { apiRequest } from "../../transport";
 
 export const description: INodeProperties[] = [
   {
     displayName:
-      'Use this operation when creating a domain fails because the domain is already verified by another team. Resend creates a placeholder domain and returns a TXT record to add to your DNS.',
-    name: 'claimDomainNotice',
-    type: 'notice',
-    default: '',
+      "Use this operation when creating a domain fails because the domain is already verified by another team. Resend creates a placeholder domain and returns a TXT record to add to your DNS.",
+    name: "claimDomainNotice",
+    type: "notice",
+    default: "",
     displayOptions: {
       show: {
-        resource: ['domains'],
-        operation: ['claim'],
+        resource: ["domains"],
+        operation: ["claim"],
       },
     },
   },
   {
-    displayName: 'Domain Name',
-    name: 'domainName',
-    type: 'string',
+    displayName: "Domain Name",
+    name: "domainName",
+    type: "string",
     required: true,
-    default: '',
-    placeholder: 'example.com',
+    default: "",
+    placeholder: "example.com",
     displayOptions: {
       show: {
-        resource: ['domains'],
-        operation: ['claim'],
+        resource: ["domains"],
+        operation: ["claim"],
       },
     },
-    description: 'The name of the domain you want to claim',
+    description: "The name of the domain you want to claim",
   },
   {
-    displayName: 'Additional Options',
-    name: 'additionalOptions',
-    type: 'collection',
-    placeholder: 'Add Option',
+    displayName: "Additional Options",
+    name: "additionalOptions",
+    type: "collection",
+    placeholder: "Add Option",
     default: {},
     displayOptions: {
       show: {
-        resource: ['domains'],
-        operation: ['claim'],
+        resource: ["domains"],
+        operation: ["claim"],
       },
     },
     options: [
       {
-        displayName: 'Click Tracking',
-        name: 'click_tracking',
-        type: 'boolean',
+        displayName: "Click Tracking",
+        name: "click_tracking",
+        type: "boolean",
         default: false,
         description:
-          'Whether to track clicks within the body of each HTML email. Only applied if a tracking_subdomain is configured and verified.',
+          "Whether to track clicks within the body of each HTML email. Only applied if a tracking_subdomain is configured and verified.",
       },
       {
-        displayName: 'Custom Return Path',
-        name: 'custom_return_path',
-        type: 'string',
-        default: 'send',
-        placeholder: 'send',
+        displayName: "Custom Return Path",
+        name: "custom_return_path",
+        type: "string",
+        default: "send",
+        placeholder: "send",
         description:
           'Choose a subdomain for the Return-Path address. Defaults to "send" (i.e., send.yourdomain.tld).',
       },
       {
-        displayName: 'Open Tracking',
-        name: 'open_tracking',
-        type: 'boolean',
+        displayName: "Open Tracking",
+        name: "open_tracking",
+        type: "boolean",
         default: false,
         description:
-          'Whether to track the open rate of each email. Only applied if a tracking_subdomain is configured and verified.',
+          "Whether to track the open rate of each email. Only applied if a tracking_subdomain is configured and verified.",
       },
       {
-        displayName: 'Region',
-        name: 'region',
-        type: 'options',
+        displayName: "Region",
+        name: "region",
+        type: "options",
         options: [
-          { name: 'US East (N. Virginia)', value: 'us-east-1' },
-          { name: 'EU West (Ireland)', value: 'eu-west-1' },
-          { name: 'South America (São Paulo)', value: 'sa-east-1' },
-          { name: 'Asia Pacific (Tokyo)', value: 'ap-northeast-1' },
+          { name: "US East (N. Virginia)", value: "us-east-1" },
+          { name: "EU West (Ireland)", value: "eu-west-1" },
+          { name: "South America (São Paulo)", value: "sa-east-1" },
+          { name: "Asia Pacific (Tokyo)", value: "ap-northeast-1" },
         ],
-        default: 'us-east-1',
-        description: 'The region where emails will be sent from',
+        default: "us-east-1",
+        description: "The region where emails will be sent from",
       },
       {
-        displayName: 'Tracking Subdomain',
-        name: 'tracking_subdomain',
-        type: 'string',
-        default: '',
-        placeholder: 'links',
+        displayName: "Tracking Subdomain",
+        name: "tracking_subdomain",
+        type: "string",
+        default: "",
+        placeholder: "links",
         description:
           'Configure a custom subdomain for click and open tracking (e.g., "links" on domain example.com produces links.example.com)',
       },
@@ -103,9 +103,9 @@ export async function execute(
   this: IExecuteFunctions,
   index: number,
 ): Promise<INodeExecutionData[]> {
-  const domainName = this.getNodeParameter('domainName', index) as string;
+  const domainName = this.getNodeParameter("domainName", index) as string;
   const additionalOptions = this.getNodeParameter(
-    'additionalOptions',
+    "additionalOptions",
     index,
   ) as IDataObject;
 
@@ -121,7 +121,7 @@ export async function execute(
   if (additionalOptions.tracking_subdomain)
     body.tracking_subdomain = additionalOptions.tracking_subdomain;
 
-  const response = await apiRequest.call(this, 'POST', '/domains/claim', body);
+  const response = await apiRequest.call(this, "POST", "/domains/claim", body);
 
   return [{ json: response, pairedItem: { item: index } }];
 }

--- a/nodes/Resend/actions/domain/claim.operation.ts
+++ b/nodes/Resend/actions/domain/claim.operation.ts
@@ -3,95 +3,95 @@ import type {
   IExecuteFunctions,
   INodeExecutionData,
   INodeProperties,
-} from "n8n-workflow";
-import { apiRequest } from "../../transport";
+} from 'n8n-workflow';
+import { apiRequest } from '../../transport';
 
 export const description: INodeProperties[] = [
   {
     displayName:
-      "Use this operation when creating a domain fails because the domain is already verified by another team. Resend creates a placeholder domain and returns a TXT record to add to your DNS.",
-    name: "claimDomainNotice",
-    type: "notice",
-    default: "",
+      'Use this operation when creating a domain fails because the domain is already verified by another team. Resend creates a placeholder domain and returns a TXT record to add to your DNS.',
+    name: 'claimDomainNotice',
+    type: 'notice',
+    default: '',
     displayOptions: {
       show: {
-        resource: ["domains"],
-        operation: ["claim"],
+        resource: ['domains'],
+        operation: ['claim'],
       },
     },
   },
   {
-    displayName: "Domain Name",
-    name: "domainName",
-    type: "string",
+    displayName: 'Domain Name',
+    name: 'domainName',
+    type: 'string',
     required: true,
-    default: "",
-    placeholder: "example.com",
+    default: '',
+    placeholder: 'example.com',
     displayOptions: {
       show: {
-        resource: ["domains"],
-        operation: ["claim"],
+        resource: ['domains'],
+        operation: ['claim'],
       },
     },
-    description: "The name of the domain you want to claim",
+    description: 'The name of the domain you want to claim',
   },
   {
-    displayName: "Additional Options",
-    name: "additionalOptions",
-    type: "collection",
-    placeholder: "Add Option",
+    displayName: 'Additional Options',
+    name: 'additionalOptions',
+    type: 'collection',
+    placeholder: 'Add Option',
     default: {},
     displayOptions: {
       show: {
-        resource: ["domains"],
-        operation: ["claim"],
+        resource: ['domains'],
+        operation: ['claim'],
       },
     },
     options: [
       {
-        displayName: "Click Tracking",
-        name: "click_tracking",
-        type: "boolean",
+        displayName: 'Click Tracking',
+        name: 'click_tracking',
+        type: 'boolean',
         default: false,
         description:
-          "Whether to track clicks within the body of each HTML email. Only applied if a tracking_subdomain is configured and verified.",
+          'Whether to track clicks within the body of each HTML email. Only applied if a tracking_subdomain is configured and verified.',
       },
       {
-        displayName: "Custom Return Path",
-        name: "custom_return_path",
-        type: "string",
-        default: "send",
-        placeholder: "send",
+        displayName: 'Custom Return Path',
+        name: 'custom_return_path',
+        type: 'string',
+        default: 'send',
+        placeholder: 'send',
         description:
           'Choose a subdomain for the Return-Path address. Defaults to "send" (i.e., send.yourdomain.tld).',
       },
       {
-        displayName: "Open Tracking",
-        name: "open_tracking",
-        type: "boolean",
+        displayName: 'Open Tracking',
+        name: 'open_tracking',
+        type: 'boolean',
         default: false,
         description:
-          "Whether to track the open rate of each email. Only applied if a tracking_subdomain is configured and verified.",
+          'Whether to track the open rate of each email. Only applied if a tracking_subdomain is configured and verified.',
       },
       {
-        displayName: "Region",
-        name: "region",
-        type: "options",
+        displayName: 'Region',
+        name: 'region',
+        type: 'options',
         options: [
-          { name: "US East (N. Virginia)", value: "us-east-1" },
-          { name: "EU West (Ireland)", value: "eu-west-1" },
-          { name: "South America (São Paulo)", value: "sa-east-1" },
-          { name: "Asia Pacific (Tokyo)", value: "ap-northeast-1" },
+          { name: 'US East (N. Virginia)', value: 'us-east-1' },
+          { name: 'EU West (Ireland)', value: 'eu-west-1' },
+          { name: 'South America (São Paulo)', value: 'sa-east-1' },
+          { name: 'Asia Pacific (Tokyo)', value: 'ap-northeast-1' },
         ],
-        default: "us-east-1",
-        description: "The region where emails will be sent from",
+        default: 'us-east-1',
+        description: 'The region where emails will be sent from',
       },
       {
-        displayName: "Tracking Subdomain",
-        name: "tracking_subdomain",
-        type: "string",
-        default: "",
-        placeholder: "links",
+        displayName: 'Tracking Subdomain',
+        name: 'tracking_subdomain',
+        type: 'string',
+        default: '',
+        placeholder: 'links',
         description:
           'Configure a custom subdomain for click and open tracking (e.g., "links" on domain example.com produces links.example.com)',
       },
@@ -103,9 +103,9 @@ export async function execute(
   this: IExecuteFunctions,
   index: number,
 ): Promise<INodeExecutionData[]> {
-  const domainName = this.getNodeParameter("domainName", index) as string;
+  const domainName = this.getNodeParameter('domainName', index) as string;
   const additionalOptions = this.getNodeParameter(
-    "additionalOptions",
+    'additionalOptions',
     index,
   ) as IDataObject;
 
@@ -121,7 +121,7 @@ export async function execute(
   if (additionalOptions.tracking_subdomain)
     body.tracking_subdomain = additionalOptions.tracking_subdomain;
 
-  const response = await apiRequest.call(this, "POST", "/domains/claim", body);
+  const response = await apiRequest.call(this, 'POST', '/domains/claim', body);
 
   return [{ json: response, pairedItem: { item: index } }];
 }

--- a/nodes/Resend/actions/domain/claim.operation.ts
+++ b/nodes/Resend/actions/domain/claim.operation.ts
@@ -1,0 +1,127 @@
+import type {
+  IDataObject,
+  IExecuteFunctions,
+  INodeExecutionData,
+  INodeProperties,
+} from 'n8n-workflow';
+import { apiRequest } from '../../transport';
+
+export const description: INodeProperties[] = [
+  {
+    displayName:
+      'Use this operation when creating a domain fails because the domain is already verified by another team. Resend creates a placeholder domain and returns a TXT record to add to your DNS.',
+    name: 'claimDomainNotice',
+    type: 'notice',
+    default: '',
+    displayOptions: {
+      show: {
+        resource: ['domains'],
+        operation: ['claim'],
+      },
+    },
+  },
+  {
+    displayName: 'Domain Name',
+    name: 'domainName',
+    type: 'string',
+    required: true,
+    default: '',
+    placeholder: 'example.com',
+    displayOptions: {
+      show: {
+        resource: ['domains'],
+        operation: ['claim'],
+      },
+    },
+    description: 'The name of the domain you want to claim',
+  },
+  {
+    displayName: 'Additional Options',
+    name: 'additionalOptions',
+    type: 'collection',
+    placeholder: 'Add Option',
+    default: {},
+    displayOptions: {
+      show: {
+        resource: ['domains'],
+        operation: ['claim'],
+      },
+    },
+    options: [
+      {
+        displayName: 'Click Tracking',
+        name: 'click_tracking',
+        type: 'boolean',
+        default: false,
+        description:
+          'Whether to track clicks within the body of each HTML email. Only applied if a tracking_subdomain is configured and verified.',
+      },
+      {
+        displayName: 'Custom Return Path',
+        name: 'custom_return_path',
+        type: 'string',
+        default: 'send',
+        placeholder: 'send',
+        description:
+          'Choose a subdomain for the Return-Path address. Defaults to "send" (i.e., send.yourdomain.tld).',
+      },
+      {
+        displayName: 'Open Tracking',
+        name: 'open_tracking',
+        type: 'boolean',
+        default: false,
+        description:
+          'Whether to track the open rate of each email. Only applied if a tracking_subdomain is configured and verified.',
+      },
+      {
+        displayName: 'Region',
+        name: 'region',
+        type: 'options',
+        options: [
+          { name: 'US East (N. Virginia)', value: 'us-east-1' },
+          { name: 'EU West (Ireland)', value: 'eu-west-1' },
+          { name: 'South America (São Paulo)', value: 'sa-east-1' },
+          { name: 'Asia Pacific (Tokyo)', value: 'ap-northeast-1' },
+        ],
+        default: 'us-east-1',
+        description: 'The region where emails will be sent from',
+      },
+      {
+        displayName: 'Tracking Subdomain',
+        name: 'tracking_subdomain',
+        type: 'string',
+        default: '',
+        placeholder: 'links',
+        description:
+          'Configure a custom subdomain for click and open tracking (e.g., "links" on domain example.com produces links.example.com)',
+      },
+    ],
+  },
+];
+
+export async function execute(
+  this: IExecuteFunctions,
+  index: number,
+): Promise<INodeExecutionData[]> {
+  const domainName = this.getNodeParameter('domainName', index) as string;
+  const additionalOptions = this.getNodeParameter(
+    'additionalOptions',
+    index,
+  ) as IDataObject;
+
+  const body: IDataObject = { name: domainName };
+
+  if (additionalOptions.region) body.region = additionalOptions.region;
+  if (additionalOptions.custom_return_path)
+    body.custom_return_path = additionalOptions.custom_return_path;
+  if (additionalOptions.open_tracking !== undefined)
+    body.open_tracking = additionalOptions.open_tracking;
+  if (additionalOptions.click_tracking !== undefined)
+    body.click_tracking = additionalOptions.click_tracking;
+  if (additionalOptions.tracking_subdomain)
+    body.tracking_subdomain = additionalOptions.tracking_subdomain;
+
+  const response = await apiRequest.call(this, 'POST', '/domains/claim', body);
+
+  return [{ json: response, pairedItem: { item: index } }];
+}

--- a/nodes/Resend/actions/domain/execute.ts
+++ b/nodes/Resend/actions/domain/execute.ts
@@ -1,24 +1,30 @@
 import { createOperationRouter } from '../../transport';
 
+import * as claim from './claim.operation';
 import * as create from './create.operation';
 import * as createTrackingDomain from './createTrackingDomain.operation';
 import * as del from './delete.operation';
 import * as deleteTrackingDomain from './deleteTrackingDomain.operation';
 import * as get from './get.operation';
+import * as getClaim from './getClaim.operation';
 import * as getTrackingDomain from './getTrackingDomain.operation';
 import * as list from './list.operation';
 import * as listTrackingDomains from './listTrackingDomains.operation';
 import * as update from './update.operation';
 import * as verify from './verify.operation';
+import * as verifyClaim from './verifyClaim.operation';
 import * as verifyTrackingDomain from './verifyTrackingDomain.operation';
 
 export const execute = createOperationRouter(
   {
+    claim,
     create,
     get,
+    getClaim,
     update,
     delete: del,
     verify,
+    verifyClaim,
     createTrackingDomain,
     getTrackingDomain,
     listTrackingDomains,

--- a/nodes/Resend/actions/domain/execute.ts
+++ b/nodes/Resend/actions/domain/execute.ts
@@ -1,19 +1,19 @@
-import { createOperationRouter } from "../../transport";
+import { createOperationRouter } from '../../transport';
 
-import * as claim from "./claim.operation";
-import * as create from "./create.operation";
-import * as createTrackingDomain from "./createTrackingDomain.operation";
-import * as del from "./delete.operation";
-import * as deleteTrackingDomain from "./deleteTrackingDomain.operation";
-import * as get from "./get.operation";
-import * as getClaim from "./getClaim.operation";
-import * as getTrackingDomain from "./getTrackingDomain.operation";
-import * as list from "./list.operation";
-import * as listTrackingDomains from "./listTrackingDomains.operation";
-import * as update from "./update.operation";
-import * as verify from "./verify.operation";
-import * as verifyClaim from "./verifyClaim.operation";
-import * as verifyTrackingDomain from "./verifyTrackingDomain.operation";
+import * as claim from './claim.operation';
+import * as create from './create.operation';
+import * as createTrackingDomain from './createTrackingDomain.operation';
+import * as del from './delete.operation';
+import * as deleteTrackingDomain from './deleteTrackingDomain.operation';
+import * as get from './get.operation';
+import * as getClaim from './getClaim.operation';
+import * as getTrackingDomain from './getTrackingDomain.operation';
+import * as list from './list.operation';
+import * as listTrackingDomains from './listTrackingDomains.operation';
+import * as update from './update.operation';
+import * as verify from './verify.operation';
+import * as verifyClaim from './verifyClaim.operation';
+import * as verifyTrackingDomain from './verifyTrackingDomain.operation';
 
 export const execute = createOperationRouter(
   {

--- a/nodes/Resend/actions/domain/execute.ts
+++ b/nodes/Resend/actions/domain/execute.ts
@@ -1,19 +1,19 @@
-import { createOperationRouter } from '../../transport';
+import { createOperationRouter } from "../../transport";
 
-import * as claim from './claim.operation';
-import * as create from './create.operation';
-import * as createTrackingDomain from './createTrackingDomain.operation';
-import * as del from './delete.operation';
-import * as deleteTrackingDomain from './deleteTrackingDomain.operation';
-import * as get from './get.operation';
-import * as getClaim from './getClaim.operation';
-import * as getTrackingDomain from './getTrackingDomain.operation';
-import * as list from './list.operation';
-import * as listTrackingDomains from './listTrackingDomains.operation';
-import * as update from './update.operation';
-import * as verify from './verify.operation';
-import * as verifyClaim from './verifyClaim.operation';
-import * as verifyTrackingDomain from './verifyTrackingDomain.operation';
+import * as claim from "./claim.operation";
+import * as create from "./create.operation";
+import * as createTrackingDomain from "./createTrackingDomain.operation";
+import * as del from "./delete.operation";
+import * as deleteTrackingDomain from "./deleteTrackingDomain.operation";
+import * as get from "./get.operation";
+import * as getClaim from "./getClaim.operation";
+import * as getTrackingDomain from "./getTrackingDomain.operation";
+import * as list from "./list.operation";
+import * as listTrackingDomains from "./listTrackingDomains.operation";
+import * as update from "./update.operation";
+import * as verify from "./verify.operation";
+import * as verifyClaim from "./verifyClaim.operation";
+import * as verifyTrackingDomain from "./verifyTrackingDomain.operation";
 
 export const execute = createOperationRouter(
   {

--- a/nodes/Resend/actions/domain/getClaim.operation.ts
+++ b/nodes/Resend/actions/domain/getClaim.operation.ts
@@ -2,26 +2,26 @@ import type {
   IExecuteFunctions,
   INodeExecutionData,
   INodeProperties,
-} from "n8n-workflow";
-import { apiRequest } from "../../transport";
+} from 'n8n-workflow';
+import { apiRequest } from '../../transport';
 import {
   createDynamicIdField,
   resolveDynamicIdValue,
-} from "../../utils/dynamicFields";
+} from '../../utils/dynamicFields';
 
 export const description: INodeProperties[] = [
   createDynamicIdField({
-    fieldName: "domainId",
-    resourceName: "domain",
-    displayName: "Domain",
+    fieldName: 'domainId',
+    resourceName: 'domain',
+    displayName: 'Domain',
     required: true,
-    placeholder: "d91cd9bd-1176-453e-8fc1-35364d380206",
+    placeholder: 'd91cd9bd-1176-453e-8fc1-35364d380206',
     description:
       'The placeholder Domain ID returned when the claim was created. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
     displayOptions: {
       show: {
-        resource: ["domains"],
-        operation: ["getClaim"],
+        resource: ['domains'],
+        operation: ['getClaim'],
       },
     },
   }),
@@ -31,11 +31,11 @@ export async function execute(
   this: IExecuteFunctions,
   index: number,
 ): Promise<INodeExecutionData[]> {
-  const domainId = resolveDynamicIdValue(this, "domainId", index);
+  const domainId = resolveDynamicIdValue(this, 'domainId', index);
 
   const response = await apiRequest.call(
     this,
-    "GET",
+    'GET',
     `/domains/${encodeURIComponent(domainId)}/claim`,
   );
 

--- a/nodes/Resend/actions/domain/getClaim.operation.ts
+++ b/nodes/Resend/actions/domain/getClaim.operation.ts
@@ -1,0 +1,43 @@
+import type {
+  IExecuteFunctions,
+  INodeExecutionData,
+  INodeProperties,
+} from 'n8n-workflow';
+import { apiRequest } from '../../transport';
+import {
+  createDynamicIdField,
+  resolveDynamicIdValue,
+} from '../../utils/dynamicFields';
+
+export const description: INodeProperties[] = [
+  createDynamicIdField({
+    fieldName: 'domainId',
+    resourceName: 'domain',
+    displayName: 'Domain',
+    required: true,
+    placeholder: 'd91cd9bd-1176-453e-8fc1-35364d380206',
+    description:
+      'The placeholder Domain ID returned when the claim was created. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+    displayOptions: {
+      show: {
+        resource: ['domains'],
+        operation: ['getClaim'],
+      },
+    },
+  }),
+];
+
+export async function execute(
+  this: IExecuteFunctions,
+  index: number,
+): Promise<INodeExecutionData[]> {
+  const domainId = resolveDynamicIdValue(this, 'domainId', index);
+
+  const response = await apiRequest.call(
+    this,
+    'GET',
+    `/domains/${encodeURIComponent(domainId)}/claim`,
+  );
+
+  return [{ json: response, pairedItem: { item: index } }];
+}

--- a/nodes/Resend/actions/domain/getClaim.operation.ts
+++ b/nodes/Resend/actions/domain/getClaim.operation.ts
@@ -2,26 +2,26 @@ import type {
   IExecuteFunctions,
   INodeExecutionData,
   INodeProperties,
-} from 'n8n-workflow';
-import { apiRequest } from '../../transport';
+} from "n8n-workflow";
+import { apiRequest } from "../../transport";
 import {
   createDynamicIdField,
   resolveDynamicIdValue,
-} from '../../utils/dynamicFields';
+} from "../../utils/dynamicFields";
 
 export const description: INodeProperties[] = [
   createDynamicIdField({
-    fieldName: 'domainId',
-    resourceName: 'domain',
-    displayName: 'Domain',
+    fieldName: "domainId",
+    resourceName: "domain",
+    displayName: "Domain",
     required: true,
-    placeholder: 'd91cd9bd-1176-453e-8fc1-35364d380206',
+    placeholder: "d91cd9bd-1176-453e-8fc1-35364d380206",
     description:
       'The placeholder Domain ID returned when the claim was created. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
     displayOptions: {
       show: {
-        resource: ['domains'],
-        operation: ['getClaim'],
+        resource: ["domains"],
+        operation: ["getClaim"],
       },
     },
   }),
@@ -31,11 +31,11 @@ export async function execute(
   this: IExecuteFunctions,
   index: number,
 ): Promise<INodeExecutionData[]> {
-  const domainId = resolveDynamicIdValue(this, 'domainId', index);
+  const domainId = resolveDynamicIdValue(this, "domainId", index);
 
   const response = await apiRequest.call(
     this,
-    'GET',
+    "GET",
     `/domains/${encodeURIComponent(domainId)}/claim`,
   );
 

--- a/nodes/Resend/actions/domain/index.ts
+++ b/nodes/Resend/actions/domain/index.ts
@@ -1,130 +1,130 @@
-import type { INodeProperties } from "n8n-workflow";
-import * as claim from "./claim.operation";
-import * as create from "./create.operation";
-import * as createTrackingDomain from "./createTrackingDomain.operation";
-import * as del from "./delete.operation";
-import * as deleteTrackingDomain from "./deleteTrackingDomain.operation";
-import * as get from "./get.operation";
-import * as getClaim from "./getClaim.operation";
-import * as getTrackingDomain from "./getTrackingDomain.operation";
-import * as list from "./list.operation";
-import * as listTrackingDomains from "./listTrackingDomains.operation";
-import * as update from "./update.operation";
-import * as verify from "./verify.operation";
-import * as verifyClaim from "./verifyClaim.operation";
-import * as verifyTrackingDomain from "./verifyTrackingDomain.operation";
+import type { INodeProperties } from 'n8n-workflow';
+import * as claim from './claim.operation';
+import * as create from './create.operation';
+import * as createTrackingDomain from './createTrackingDomain.operation';
+import * as del from './delete.operation';
+import * as deleteTrackingDomain from './deleteTrackingDomain.operation';
+import * as get from './get.operation';
+import * as getClaim from './getClaim.operation';
+import * as getTrackingDomain from './getTrackingDomain.operation';
+import * as list from './list.operation';
+import * as listTrackingDomains from './listTrackingDomains.operation';
+import * as update from './update.operation';
+import * as verify from './verify.operation';
+import * as verifyClaim from './verifyClaim.operation';
+import * as verifyTrackingDomain from './verifyTrackingDomain.operation';
 
 export const operations: INodeProperties[] = [
   {
-    displayName: "Operation",
-    name: "operation",
-    type: "options",
+    displayName: 'Operation',
+    name: 'operation',
+    type: 'options',
     noDataExpression: true,
     displayOptions: {
       show: {
-        resource: ["domains"],
+        resource: ['domains'],
       },
     },
     options: [
       {
-        name: "Claim",
-        value: "claim",
+        name: 'Claim',
+        value: 'claim',
         description:
-          "Claim a domain already verified by another team. Returns a TXT record to add to your DNS for ownership verification.",
-        action: "Claim a domain from another team",
+          'Claim a domain already verified by another team. Returns a TXT record to add to your DNS for ownership verification.',
+        action: 'Claim a domain from another team',
       },
       {
-        name: "Create",
-        value: "create",
+        name: 'Create',
+        value: 'create',
         description:
-          "Add a new sending domain for email authentication. Returns DNS records that must be configured for verification.",
-        action: "Add a new sending domain",
+          'Add a new sending domain for email authentication. Returns DNS records that must be configured for verification.',
+        action: 'Add a new sending domain',
       },
       {
-        name: "Create Tracking Domain",
-        value: "createTrackingDomain",
+        name: 'Create Tracking Domain',
+        value: 'createTrackingDomain',
         description:
-          "Create a custom domain for click and open tracking (private alpha)",
-        action: "Create a tracking domain",
+          'Create a custom domain for click and open tracking (private alpha)',
+        action: 'Create a tracking domain',
       },
       {
-        name: "Delete",
-        value: "delete",
+        name: 'Delete',
+        value: 'delete',
         description:
-          "Remove a sending domain from your account. Emails can no longer be sent from this domain after deletion.",
-        action: "Delete a domain",
+          'Remove a sending domain from your account. Emails can no longer be sent from this domain after deletion.',
+        action: 'Delete a domain',
       },
       {
-        name: "Delete Tracking Domain",
-        value: "deleteTrackingDomain",
-        description: "Remove an existing click tracking domain (private alpha)",
-        action: "Delete a tracking domain",
+        name: 'Delete Tracking Domain',
+        value: 'deleteTrackingDomain',
+        description: 'Remove an existing click tracking domain (private alpha)',
+        action: 'Delete a tracking domain',
       },
       {
-        name: "Get",
-        value: "get",
+        name: 'Get',
+        value: 'get',
         description:
-          "Retrieve details of a domain including DNS records, verification status, and configuration",
-        action: "Get domain details",
+          'Retrieve details of a domain including DNS records, verification status, and configuration',
+        action: 'Get domain details',
       },
       {
-        name: "Get Claim",
-        value: "getClaim",
+        name: 'Get Claim',
+        value: 'getClaim',
         description:
-          "Retrieve the latest claim status for a domain. Poll this endpoint to follow a claim status after starting a claim.",
-        action: "Get domain claim status",
+          'Retrieve the latest claim status for a domain. Poll this endpoint to follow a claim status after starting a claim.',
+        action: 'Get domain claim status',
       },
       {
-        name: "Get Tracking Domain",
-        value: "getTrackingDomain",
+        name: 'Get Tracking Domain',
+        value: 'getTrackingDomain',
         description:
-          "Retrieve a single click tracking domain with its DNS records and verification status (private alpha)",
-        action: "Get tracking domain details",
+          'Retrieve a single click tracking domain with its DNS records and verification status (private alpha)',
+        action: 'Get tracking domain details',
       },
       {
-        name: "List",
-        value: "list",
+        name: 'List',
+        value: 'list',
         description:
-          "Get all sending domains with their verification status and DNS record requirements",
-        action: "List all domains",
+          'Get all sending domains with their verification status and DNS record requirements',
+        action: 'List all domains',
       },
       {
-        name: "List Tracking Domains",
-        value: "listTrackingDomains",
+        name: 'List Tracking Domains',
+        value: 'listTrackingDomains',
         description:
-          "List all tracking domains for a given domain (private alpha)",
-        action: "List tracking domains",
+          'List all tracking domains for a given domain (private alpha)',
+        action: 'List tracking domains',
       },
       {
-        name: "Update",
-        value: "update",
+        name: 'Update',
+        value: 'update',
         description:
-          "Update domain settings such as click tracking, open tracking, or TLS requirements",
-        action: "Update domain settings",
+          'Update domain settings such as click tracking, open tracking, or TLS requirements',
+        action: 'Update domain settings',
       },
       {
-        name: "Verify",
-        value: "verify",
+        name: 'Verify',
+        value: 'verify',
         description:
-          "Trigger verification of DNS records for a domain. Use after configuring DNS to check if domain is ready for sending.",
-        action: "Verify domain DNS records",
+          'Trigger verification of DNS records for a domain. Use after configuring DNS to check if domain is ready for sending.',
+        action: 'Verify domain DNS records',
       },
       {
-        name: "Verify Claim",
-        value: "verifyClaim",
+        name: 'Verify Claim',
+        value: 'verifyClaim',
         description:
-          "Trigger DNS verification for a domain claim. Add the TXT record from the Claim operation before calling this.",
-        action: "Verify domain claim ownership",
+          'Trigger DNS verification for a domain claim. Add the TXT record from the Claim operation before calling this.',
+        action: 'Verify domain claim ownership',
       },
       {
-        name: "Verify Tracking Domain",
-        value: "verifyTrackingDomain",
+        name: 'Verify Tracking Domain',
+        value: 'verifyTrackingDomain',
         description:
-          "Trigger DNS verification for a tracking domain (private alpha)",
-        action: "Verify a tracking domain",
+          'Trigger DNS verification for a tracking domain (private alpha)',
+        action: 'Verify a tracking domain',
       },
     ],
-    default: "list",
+    default: 'list',
   },
 ];
 
@@ -146,7 +146,7 @@ export const descriptions: INodeProperties[] = [
   ...verifyTrackingDomain.description,
 ];
 
-export { execute } from "./execute";
+export { execute } from './execute';
 export {
   claim,
   create,

--- a/nodes/Resend/actions/domain/index.ts
+++ b/nodes/Resend/actions/domain/index.ts
@@ -1,130 +1,130 @@
-import type { INodeProperties } from 'n8n-workflow';
-import * as claim from './claim.operation';
-import * as create from './create.operation';
-import * as createTrackingDomain from './createTrackingDomain.operation';
-import * as del from './delete.operation';
-import * as deleteTrackingDomain from './deleteTrackingDomain.operation';
-import * as get from './get.operation';
-import * as getClaim from './getClaim.operation';
-import * as getTrackingDomain from './getTrackingDomain.operation';
-import * as list from './list.operation';
-import * as listTrackingDomains from './listTrackingDomains.operation';
-import * as update from './update.operation';
-import * as verify from './verify.operation';
-import * as verifyClaim from './verifyClaim.operation';
-import * as verifyTrackingDomain from './verifyTrackingDomain.operation';
+import type { INodeProperties } from "n8n-workflow";
+import * as claim from "./claim.operation";
+import * as create from "./create.operation";
+import * as createTrackingDomain from "./createTrackingDomain.operation";
+import * as del from "./delete.operation";
+import * as deleteTrackingDomain from "./deleteTrackingDomain.operation";
+import * as get from "./get.operation";
+import * as getClaim from "./getClaim.operation";
+import * as getTrackingDomain from "./getTrackingDomain.operation";
+import * as list from "./list.operation";
+import * as listTrackingDomains from "./listTrackingDomains.operation";
+import * as update from "./update.operation";
+import * as verify from "./verify.operation";
+import * as verifyClaim from "./verifyClaim.operation";
+import * as verifyTrackingDomain from "./verifyTrackingDomain.operation";
 
 export const operations: INodeProperties[] = [
   {
-    displayName: 'Operation',
-    name: 'operation',
-    type: 'options',
+    displayName: "Operation",
+    name: "operation",
+    type: "options",
     noDataExpression: true,
     displayOptions: {
       show: {
-        resource: ['domains'],
+        resource: ["domains"],
       },
     },
     options: [
       {
-        name: 'Claim',
-        value: 'claim',
+        name: "Claim",
+        value: "claim",
         description:
-          'Claim a domain already verified by another team. Returns a TXT record to add to your DNS for ownership verification.',
-        action: 'Claim a domain from another team',
+          "Claim a domain already verified by another team. Returns a TXT record to add to your DNS for ownership verification.",
+        action: "Claim a domain from another team",
       },
       {
-        name: 'Create',
-        value: 'create',
+        name: "Create",
+        value: "create",
         description:
-          'Add a new sending domain for email authentication. Returns DNS records that must be configured for verification.',
-        action: 'Add a new sending domain',
+          "Add a new sending domain for email authentication. Returns DNS records that must be configured for verification.",
+        action: "Add a new sending domain",
       },
       {
-        name: 'Create Tracking Domain',
-        value: 'createTrackingDomain',
+        name: "Create Tracking Domain",
+        value: "createTrackingDomain",
         description:
-          'Create a custom domain for click and open tracking (private alpha)',
-        action: 'Create a tracking domain',
+          "Create a custom domain for click and open tracking (private alpha)",
+        action: "Create a tracking domain",
       },
       {
-        name: 'Delete',
-        value: 'delete',
+        name: "Delete",
+        value: "delete",
         description:
-          'Remove a sending domain from your account. Emails can no longer be sent from this domain after deletion.',
-        action: 'Delete a domain',
+          "Remove a sending domain from your account. Emails can no longer be sent from this domain after deletion.",
+        action: "Delete a domain",
       },
       {
-        name: 'Delete Tracking Domain',
-        value: 'deleteTrackingDomain',
-        description: 'Remove an existing click tracking domain (private alpha)',
-        action: 'Delete a tracking domain',
+        name: "Delete Tracking Domain",
+        value: "deleteTrackingDomain",
+        description: "Remove an existing click tracking domain (private alpha)",
+        action: "Delete a tracking domain",
       },
       {
-        name: 'Get',
-        value: 'get',
+        name: "Get",
+        value: "get",
         description:
-          'Retrieve details of a domain including DNS records, verification status, and configuration',
-        action: 'Get domain details',
+          "Retrieve details of a domain including DNS records, verification status, and configuration",
+        action: "Get domain details",
       },
       {
-        name: 'Get Claim',
-        value: 'getClaim',
+        name: "Get Claim",
+        value: "getClaim",
         description:
-          'Retrieve the latest claim status for a domain. Poll this endpoint to follow a claim status after starting a claim.',
-        action: 'Get domain claim status',
+          "Retrieve the latest claim status for a domain. Poll this endpoint to follow a claim status after starting a claim.",
+        action: "Get domain claim status",
       },
       {
-        name: 'Get Tracking Domain',
-        value: 'getTrackingDomain',
+        name: "Get Tracking Domain",
+        value: "getTrackingDomain",
         description:
-          'Retrieve a single click tracking domain with its DNS records and verification status (private alpha)',
-        action: 'Get tracking domain details',
+          "Retrieve a single click tracking domain with its DNS records and verification status (private alpha)",
+        action: "Get tracking domain details",
       },
       {
-        name: 'List',
-        value: 'list',
+        name: "List",
+        value: "list",
         description:
-          'Get all sending domains with their verification status and DNS record requirements',
-        action: 'List all domains',
+          "Get all sending domains with their verification status and DNS record requirements",
+        action: "List all domains",
       },
       {
-        name: 'List Tracking Domains',
-        value: 'listTrackingDomains',
+        name: "List Tracking Domains",
+        value: "listTrackingDomains",
         description:
-          'List all tracking domains for a given domain (private alpha)',
-        action: 'List tracking domains',
+          "List all tracking domains for a given domain (private alpha)",
+        action: "List tracking domains",
       },
       {
-        name: 'Update',
-        value: 'update',
+        name: "Update",
+        value: "update",
         description:
-          'Update domain settings such as click tracking, open tracking, or TLS requirements',
-        action: 'Update domain settings',
+          "Update domain settings such as click tracking, open tracking, or TLS requirements",
+        action: "Update domain settings",
       },
       {
-        name: 'Verify',
-        value: 'verify',
+        name: "Verify",
+        value: "verify",
         description:
-          'Trigger verification of DNS records for a domain. Use after configuring DNS to check if domain is ready for sending.',
-        action: 'Verify domain DNS records',
+          "Trigger verification of DNS records for a domain. Use after configuring DNS to check if domain is ready for sending.",
+        action: "Verify domain DNS records",
       },
       {
-        name: 'Verify Claim',
-        value: 'verifyClaim',
+        name: "Verify Claim",
+        value: "verifyClaim",
         description:
-          'Trigger DNS verification for a domain claim. Add the TXT record from the Claim operation before calling this.',
-        action: 'Verify domain claim ownership',
+          "Trigger DNS verification for a domain claim. Add the TXT record from the Claim operation before calling this.",
+        action: "Verify domain claim ownership",
       },
       {
-        name: 'Verify Tracking Domain',
-        value: 'verifyTrackingDomain',
+        name: "Verify Tracking Domain",
+        value: "verifyTrackingDomain",
         description:
-          'Trigger DNS verification for a tracking domain (private alpha)',
-        action: 'Verify a tracking domain',
+          "Trigger DNS verification for a tracking domain (private alpha)",
+        action: "Verify a tracking domain",
       },
     ],
-    default: 'list',
+    default: "list",
   },
 ];
 
@@ -146,7 +146,7 @@ export const descriptions: INodeProperties[] = [
   ...verifyTrackingDomain.description,
 ];
 
-export { execute } from './execute';
+export { execute } from "./execute";
 export {
   claim,
   create,

--- a/nodes/Resend/actions/domain/index.ts
+++ b/nodes/Resend/actions/domain/index.ts
@@ -1,14 +1,17 @@
 import type { INodeProperties } from 'n8n-workflow';
+import * as claim from './claim.operation';
 import * as create from './create.operation';
 import * as createTrackingDomain from './createTrackingDomain.operation';
 import * as del from './delete.operation';
 import * as deleteTrackingDomain from './deleteTrackingDomain.operation';
 import * as get from './get.operation';
+import * as getClaim from './getClaim.operation';
 import * as getTrackingDomain from './getTrackingDomain.operation';
 import * as list from './list.operation';
 import * as listTrackingDomains from './listTrackingDomains.operation';
 import * as update from './update.operation';
 import * as verify from './verify.operation';
+import * as verifyClaim from './verifyClaim.operation';
 import * as verifyTrackingDomain from './verifyTrackingDomain.operation';
 
 export const operations: INodeProperties[] = [
@@ -23,6 +26,13 @@ export const operations: INodeProperties[] = [
       },
     },
     options: [
+      {
+        name: 'Claim',
+        value: 'claim',
+        description:
+          'Claim a domain already verified by another team. Returns a TXT record to add to your DNS for ownership verification.',
+        action: 'Claim a domain from another team',
+      },
       {
         name: 'Create',
         value: 'create',
@@ -56,6 +66,13 @@ export const operations: INodeProperties[] = [
         description:
           'Retrieve details of a domain including DNS records, verification status, and configuration',
         action: 'Get domain details',
+      },
+      {
+        name: 'Get Claim',
+        value: 'getClaim',
+        description:
+          'Retrieve the latest claim status for a domain. Poll this endpoint to follow a claim status after starting a claim.',
+        action: 'Get domain claim status',
       },
       {
         name: 'Get Tracking Domain',
@@ -93,6 +110,13 @@ export const operations: INodeProperties[] = [
         action: 'Verify domain DNS records',
       },
       {
+        name: 'Verify Claim',
+        value: 'verifyClaim',
+        description:
+          'Trigger DNS verification for a domain claim. Add the TXT record from the Claim operation before calling this.',
+        action: 'Verify domain claim ownership',
+      },
+      {
         name: 'Verify Tracking Domain',
         value: 'verifyTrackingDomain',
         description:
@@ -106,12 +130,15 @@ export const operations: INodeProperties[] = [
 
 export const descriptions: INodeProperties[] = [
   ...operations,
+  ...claim.description,
   ...create.description,
   ...get.description,
+  ...getClaim.description,
   ...list.description,
   ...update.description,
   ...del.description,
   ...verify.description,
+  ...verifyClaim.description,
   ...createTrackingDomain.description,
   ...getTrackingDomain.description,
   ...listTrackingDomains.description,
@@ -121,15 +148,18 @@ export const descriptions: INodeProperties[] = [
 
 export { execute } from './execute';
 export {
+  claim,
   create,
   createTrackingDomain,
   del as delete,
   deleteTrackingDomain,
   get,
+  getClaim,
   getTrackingDomain,
   list,
   listTrackingDomains,
   update,
   verify,
+  verifyClaim,
   verifyTrackingDomain,
 };

--- a/nodes/Resend/actions/domain/verifyClaim.operation.ts
+++ b/nodes/Resend/actions/domain/verifyClaim.operation.ts
@@ -2,39 +2,39 @@ import type {
   IExecuteFunctions,
   INodeExecutionData,
   INodeProperties,
-} from 'n8n-workflow';
-import { apiRequest } from '../../transport';
+} from "n8n-workflow";
+import { apiRequest } from "../../transport";
 import {
   createDynamicIdField,
   resolveDynamicIdValue,
-} from '../../utils/dynamicFields';
+} from "../../utils/dynamicFields";
 
 export const description: INodeProperties[] = [
   {
     displayName:
-      'Add the TXT record returned by the Claim Domain operation before calling this. Resend checks the TXT record and runs ownership-safety checks before transferring the domain. Poll Get Domain Claim to follow the status.',
-    name: 'verifyClaimNotice',
-    type: 'notice',
-    default: '',
+      "Add the TXT record returned by the Claim Domain operation before calling this. Resend checks the TXT record and runs ownership-safety checks before transferring the domain. Poll Get Domain Claim to follow the status.",
+    name: "verifyClaimNotice",
+    type: "notice",
+    default: "",
     displayOptions: {
       show: {
-        resource: ['domains'],
-        operation: ['verifyClaim'],
+        resource: ["domains"],
+        operation: ["verifyClaim"],
       },
     },
   },
   createDynamicIdField({
-    fieldName: 'domainId',
-    resourceName: 'domain',
-    displayName: 'Domain',
+    fieldName: "domainId",
+    resourceName: "domain",
+    displayName: "Domain",
     required: true,
-    placeholder: 'd91cd9bd-1176-453e-8fc1-35364d380206',
+    placeholder: "d91cd9bd-1176-453e-8fc1-35364d380206",
     description:
       'The placeholder Domain ID returned when the claim was created. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
     displayOptions: {
       show: {
-        resource: ['domains'],
-        operation: ['verifyClaim'],
+        resource: ["domains"],
+        operation: ["verifyClaim"],
       },
     },
   }),
@@ -44,11 +44,11 @@ export async function execute(
   this: IExecuteFunctions,
   index: number,
 ): Promise<INodeExecutionData[]> {
-  const domainId = resolveDynamicIdValue(this, 'domainId', index);
+  const domainId = resolveDynamicIdValue(this, "domainId", index);
 
   const response = await apiRequest.call(
     this,
-    'POST',
+    "POST",
     `/domains/${encodeURIComponent(domainId)}/claim/verify`,
   );
 

--- a/nodes/Resend/actions/domain/verifyClaim.operation.ts
+++ b/nodes/Resend/actions/domain/verifyClaim.operation.ts
@@ -2,39 +2,39 @@ import type {
   IExecuteFunctions,
   INodeExecutionData,
   INodeProperties,
-} from "n8n-workflow";
-import { apiRequest } from "../../transport";
+} from 'n8n-workflow';
+import { apiRequest } from '../../transport';
 import {
   createDynamicIdField,
   resolveDynamicIdValue,
-} from "../../utils/dynamicFields";
+} from '../../utils/dynamicFields';
 
 export const description: INodeProperties[] = [
   {
     displayName:
-      "Add the TXT record returned by the Claim Domain operation before calling this. Resend checks the TXT record and runs ownership-safety checks before transferring the domain. Poll Get Domain Claim to follow the status.",
-    name: "verifyClaimNotice",
-    type: "notice",
-    default: "",
+      'Add the TXT record returned by the Claim Domain operation before calling this. Resend checks the TXT record and runs ownership-safety checks before transferring the domain. Poll Get Domain Claim to follow the status.',
+    name: 'verifyClaimNotice',
+    type: 'notice',
+    default: '',
     displayOptions: {
       show: {
-        resource: ["domains"],
-        operation: ["verifyClaim"],
+        resource: ['domains'],
+        operation: ['verifyClaim'],
       },
     },
   },
   createDynamicIdField({
-    fieldName: "domainId",
-    resourceName: "domain",
-    displayName: "Domain",
+    fieldName: 'domainId',
+    resourceName: 'domain',
+    displayName: 'Domain',
     required: true,
-    placeholder: "d91cd9bd-1176-453e-8fc1-35364d380206",
+    placeholder: 'd91cd9bd-1176-453e-8fc1-35364d380206',
     description:
       'The placeholder Domain ID returned when the claim was created. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
     displayOptions: {
       show: {
-        resource: ["domains"],
-        operation: ["verifyClaim"],
+        resource: ['domains'],
+        operation: ['verifyClaim'],
       },
     },
   }),
@@ -44,11 +44,11 @@ export async function execute(
   this: IExecuteFunctions,
   index: number,
 ): Promise<INodeExecutionData[]> {
-  const domainId = resolveDynamicIdValue(this, "domainId", index);
+  const domainId = resolveDynamicIdValue(this, 'domainId', index);
 
   const response = await apiRequest.call(
     this,
-    "POST",
+    'POST',
     `/domains/${encodeURIComponent(domainId)}/claim/verify`,
   );
 

--- a/nodes/Resend/actions/domain/verifyClaim.operation.ts
+++ b/nodes/Resend/actions/domain/verifyClaim.operation.ts
@@ -1,0 +1,56 @@
+import type {
+  IExecuteFunctions,
+  INodeExecutionData,
+  INodeProperties,
+} from 'n8n-workflow';
+import { apiRequest } from '../../transport';
+import {
+  createDynamicIdField,
+  resolveDynamicIdValue,
+} from '../../utils/dynamicFields';
+
+export const description: INodeProperties[] = [
+  {
+    displayName:
+      'Add the TXT record returned by the Claim Domain operation before calling this. Resend checks the TXT record and runs ownership-safety checks before transferring the domain. Poll Get Domain Claim to follow the status.',
+    name: 'verifyClaimNotice',
+    type: 'notice',
+    default: '',
+    displayOptions: {
+      show: {
+        resource: ['domains'],
+        operation: ['verifyClaim'],
+      },
+    },
+  },
+  createDynamicIdField({
+    fieldName: 'domainId',
+    resourceName: 'domain',
+    displayName: 'Domain',
+    required: true,
+    placeholder: 'd91cd9bd-1176-453e-8fc1-35364d380206',
+    description:
+      'The placeholder Domain ID returned when the claim was created. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+    displayOptions: {
+      show: {
+        resource: ['domains'],
+        operation: ['verifyClaim'],
+      },
+    },
+  }),
+];
+
+export async function execute(
+  this: IExecuteFunctions,
+  index: number,
+): Promise<INodeExecutionData[]> {
+  const domainId = resolveDynamicIdValue(this, 'domainId', index);
+
+  const response = await apiRequest.call(
+    this,
+    'POST',
+    `/domains/${encodeURIComponent(domainId)}/claim/verify`,
+  );
+
+  return [{ json: response, pairedItem: { item: index } }];
+}

--- a/package.json
+++ b/package.json
@@ -57,14 +57,14 @@
     ]
   },
   "devDependencies": {
-    "@biomejs/biome": "~2.4.15",
+    "@biomejs/biome": "~2.5.3",
     "@types/jest": "^30.0.0",
-    "@types/node": "^25.2.3",
-    "auto-changelog": "^2.5.0",
+    "@types/node": "^26.1.1",
+    "auto-changelog": "^2.6.0",
     "rimraf": "^6.1.3",
-    "tsdown": "^0.22.0",
-    "typescript": "^5.9.3",
-    "unrun": "^0.3.0"
+    "tsdown": "^0.22.4",
+    "typescript": "^7.0.2",
+    "unrun": "^0.3.1"
   },
   "peerDependencies": {
     "n8n-workflow": "*"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -13,130 +13,105 @@ importers:
         version: 2.16.0
     devDependencies:
       '@biomejs/biome':
-        specifier: ~2.4.15
-        version: 2.4.15
+        specifier: ~2.5.3
+        version: 2.5.3
       '@types/jest':
         specifier: ^30.0.0
         version: 30.0.0
       '@types/node':
-        specifier: ^25.2.3
-        version: 25.7.0
+        specifier: ^26.1.1
+        version: 26.1.1
       auto-changelog:
-        specifier: ^2.5.0
-        version: 2.5.1
+        specifier: ^2.6.0
+        version: 2.6.0
       rimraf:
         specifier: ^6.1.3
         version: 6.1.3
       tsdown:
-        specifier: ^0.22.0
-        version: 0.22.0(typescript@5.9.3)(unrun@0.3.0)
+        specifier: ^0.22.4
+        version: 0.22.4(typescript@7.0.2)(unrun@0.3.1)
       typescript:
-        specifier: ^5.9.3
-        version: 5.9.3
+        specifier: ^7.0.2
+        version: 7.0.2
       unrun:
-        specifier: ^0.3.0
-        version: 0.3.0
+        specifier: ^0.3.1
+        version: 0.3.1
 
 packages:
 
-  '@babel/code-frame@7.29.0':
-    resolution: {integrity: sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==}
+  '@babel/code-frame@7.29.7':
+    resolution: {integrity: sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/generator@8.0.0-rc.4':
-    resolution: {integrity: sha512-YZ+FuIgkj7KrIb2a2X1XiY0QYgDxAbVbYP64SjwJzOK3euCsUerzenh2oqdsmKuPSlhzmFOOklnxzHAzXagvpw==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-
-  '@babel/helper-string-parser@8.0.0-rc.5':
-    resolution: {integrity: sha512-sN7R8rBvDurfaziNfDEIjIntlazmlkCDGO4SNl2RJ3wRCn+QxspLV7hzYAE8WWVd2joVuT8sUxeePdLp2idI1A==}
-    engines: {node: ^22.18.0 || >=24.11.0}
-
-  '@babel/helper-validator-identifier@7.28.5':
-    resolution: {integrity: sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==}
+  '@babel/helper-validator-identifier@7.29.7':
+    resolution: {integrity: sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/helper-validator-identifier@8.0.0-rc.4':
-    resolution: {integrity: sha512-HTD3bskipk5MSm08twTW6832jzIXUhxMddy4NPPzIMuyMEsrs0ZgwAaMj5ubB5+6hMlUjDu17vNconEmwsmpYg==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-
-  '@babel/helper-validator-identifier@8.0.0-rc.5':
-    resolution: {integrity: sha512-ehJDxHvtbZ85RtX/L2fi0h9AGsBNqB5Euv1EB8RMAvGYvD+2X+QbpzzOpbklnNXO+WSZJNOaetw2BBj27xsWVg==}
-    engines: {node: ^22.18.0 || >=24.11.0}
-
-  '@babel/parser@8.0.0-rc.4':
-    resolution: {integrity: sha512-0S/1yefMa15N4i2v3t8Fw9pgMHhf2gF6Lc1UEXI96Ls6FNAjqvHHZouZ2ZS/deqLhbMFtmfVeFac6iTsvFbLwA==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    hasBin: true
-
-  '@babel/types@8.0.0-rc.5':
-    resolution: {integrity: sha512-JeSVu/m8x/zpp4CLjYHVNXuhEyOkhPXuxM8YOXjh6L4LlvQNKuUNOTo5KdBuKAcTDHw8DquToTaEkhsBqPXOaA==}
-    engines: {node: ^22.18.0 || >=24.11.0}
-
-  '@biomejs/biome@2.4.15':
-    resolution: {integrity: sha512-j5VH3a/h/HXTKBM50MDMxRCzkeLv9S2XJcW2WgnZT1+xyisi+0bISrXR82gCX+8S9lvK0skEvHJRN+3Ktr2hlw==}
+  '@biomejs/biome@2.5.3':
+    resolution: {integrity: sha512-MrJswFdei9EfDwwUy2tQrPDpK0AO+RmMFvBoaaJ6ayBc3sUbHdCE+XG5N8vp+5So41ZupZJQm0roHFFhMGVD7A==}
     engines: {node: '>=14.21.3'}
     hasBin: true
 
-  '@biomejs/cli-darwin-arm64@2.4.15':
-    resolution: {integrity: sha512-rF3PPqLq1yoST79zaQbDjVJwsuIeci/O+9bgNmC5QpgOqz6aqYuzA4abyAGx+mgyiDXn4A049xAN8gijbuR1Qg==}
+  '@biomejs/cli-darwin-arm64@2.5.3':
+    resolution: {integrity: sha512-QhYP9muVQ0nUO5zztFuPbEwi4+94sJWVjaZds9aMi1l/KNZBiUjdiSUrGHsTaMGDXrYl+r4AS2sUKfgH3w+V3g==}
     engines: {node: '>=14.21.3'}
     cpu: [arm64]
     os: [darwin]
 
-  '@biomejs/cli-darwin-x64@2.4.15':
-    resolution: {integrity: sha512-/5KHXYMfSJs1fNXiX30xFtI8JcCFV6zaVVLxOa0M2sfqBKHkpQhRTv94yxQWxeTY2lzo2OuTlNvPC+hDQt2wcQ==}
+  '@biomejs/cli-darwin-x64@2.5.3':
+    resolution: {integrity: sha512-NC1Ss13UaW7QZX+y8j44bF7AP0jSJdBl6iRhe0MAkvaSqZy+mWg3GaXsrb+eSoHoGDBtaXWEbMVV0iVN2cZ7cQ==}
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [darwin]
 
-  '@biomejs/cli-linux-arm64-musl@2.4.15':
-    resolution: {integrity: sha512-ZPcxznxm0pogHBLZhYntyR3sR+MrZjqJIKEr7ZqVen0Rl+P/4upVmfYXjftizi9RoqZntg33fv/1fbdhbYXpEQ==}
+  '@biomejs/cli-linux-arm64-musl@2.5.3':
+    resolution: {integrity: sha512-fccix0w6xp6csCXgxeC0dU/3ecgRQal0y+cv2SP9ajNlhe7Yrk2Ug7UDe2j9AT9ZDYitkXpvUKgZjjuoYeP4Vg==}
     engines: {node: '>=14.21.3'}
     cpu: [arm64]
     os: [linux]
     libc: [musl]
 
-  '@biomejs/cli-linux-arm64@2.4.15':
-    resolution: {integrity: sha512-owaAMZD/T4LrD0ELNCk0Km3qrRHuM0X6EAyVE1FSqGY0rbLoiDLrO4Us2tllm6cAeB2Ioa9C2C08NZPdr8+0Ug==}
+  '@biomejs/cli-linux-arm64@2.5.3':
+    resolution: {integrity: sha512-ksx1KWeyYW18ILL04msF/J4ZBtBDN33znYK8Z/aNv/vlBVxL9/g3mGP+omgHJKy4+KWbK87vcmmpmurfNjSgiA==}
     engines: {node: '>=14.21.3'}
     cpu: [arm64]
     os: [linux]
     libc: [glibc]
 
-  '@biomejs/cli-linux-x64-musl@2.4.15':
-    resolution: {integrity: sha512-CNq/9W38SYSH023lfcQ4KKU8K0YX8T//FZUhcgtMMRABDojx5XsMV7jlweAvGSl389wJQB29Qo6Zb/a+jdvt+w==}
+  '@biomejs/cli-linux-x64-musl@2.5.3':
+    resolution: {integrity: sha512-O/yU9YKRUiHhmcjF2f38PSjseVk3G4VLWYc0G2HWpzdBVREV6G8IGWIVEFf7MFPfWIzNUIvPsEjeAZQIOgnLcQ==}
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [linux]
     libc: [musl]
 
-  '@biomejs/cli-linux-x64@2.4.15':
-    resolution: {integrity: sha512-0jj7THz12GbUOLmMibktK6DZjqz2zV64KFxyBtcFTKPiiOIY0a7vns1elpO1dERvxpsZ5ik0oFfz0oGwFde1+g==}
+  '@biomejs/cli-linux-x64@2.5.3':
+    resolution: {integrity: sha512-yMkJtilsgvILDcVkh187aVLTb64xYsrxYajx5kym+r1ULkO5HUOfu9AYKLGQbOVLwJtT2utNw7hhFNg+17mUYA==}
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [linux]
     libc: [glibc]
 
-  '@biomejs/cli-win32-arm64@2.4.15':
-    resolution: {integrity: sha512-ouhkYdlhp/1GghEJPdWwD/Vi3gQ1nFxuSpMolWsbq3Lsq3QUR4jl6UdhhscdCugKU5vOEuMiJhvKj66O0OCq+w==}
+  '@biomejs/cli-win32-arm64@2.5.3':
+    resolution: {integrity: sha512-cX5z+GYwRcqEok0AH3KSfQGgqYd0Nomfp6Fbe1uiTtELE38hdH2k842wQ9wLNaF/JJ7r4rjJQ4VR+ce+fRmQbw==}
     engines: {node: '>=14.21.3'}
     cpu: [arm64]
     os: [win32]
 
-  '@biomejs/cli-win32-x64@2.4.15':
-    resolution: {integrity: sha512-zBrGq5mx5wwpnow4+2BxUvleDM+GNd4sLbPaMapsSLQLD0NGRCquqPBTgN+7XkUteHvj7M+BstuI8tmnV7+HgQ==}
+  '@biomejs/cli-win32-x64@2.5.3':
+    resolution: {integrity: sha512-ExSaJWi4/u6+GXCszlSKpWSjKNbDseAYqqkCznsCsZ/4uidZ/BEqsCc5/3ctlq6dfIubdIIRSVLC/PG9xPl70Q==}
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [win32]
 
-  '@emnapi/core@1.10.0':
-    resolution: {integrity: sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==}
+  '@emnapi/core@1.11.1':
+    resolution: {integrity: sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ==}
 
-  '@emnapi/runtime@1.10.0':
-    resolution: {integrity: sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==}
+  '@emnapi/runtime@1.11.1':
+    resolution: {integrity: sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw==}
 
-  '@emnapi/wasi-threads@1.2.1':
-    resolution: {integrity: sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==}
+  '@emnapi/wasi-threads@1.2.2':
+    resolution: {integrity: sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==}
 
   '@jest/diff-sequences@30.4.0':
     resolution: {integrity: sha512-zOpzlfUs45l6u7jm39qr87JCHUDsaeCtvL+kQe/Vn9jSnRB4/5IPXISm0h9I1vZW/o00Kn4UTJ2MOlhnUGwv3g==}
@@ -162,19 +137,6 @@ packages:
     resolution: {integrity: sha512-f1x/vJXIfjOlEmejYpbkbgw1gOqpPECwMvMEtBqe47j7H2Hg8h8w3o3ikhSXq3MI15kg+oQ0exWO0uCtTNJLoQ==}
     engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
 
-  '@jridgewell/gen-mapping@0.3.13':
-    resolution: {integrity: sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==}
-
-  '@jridgewell/resolve-uri@3.1.2':
-    resolution: {integrity: sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==}
-    engines: {node: '>=6.0.0'}
-
-  '@jridgewell/sourcemap-codec@1.5.5':
-    resolution: {integrity: sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==}
-
-  '@jridgewell/trace-mapping@0.3.31':
-    resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
-
   '@n8n/errors@0.6.0':
     resolution: {integrity: sha512-oVJ0lgRYJY6/aPOW2h37ea5T+nX7/wULRn5FymwYeaiYlsLdqwIQEtGwZrajpzxJB0Os74u4lSH3WWQgZCkgxQ==}
 
@@ -188,109 +150,109 @@ packages:
   '@n8n_io/riot-tmpl@4.0.1':
     resolution: {integrity: sha512-/zdRbEfTFjsm1NqnpPQHgZTkTdbp5v3VUxGeMA9098sps8jRCTraQkc3AQstJgHUm7ylBXJcIVhnVeLUMWAfwQ==}
 
-  '@napi-rs/wasm-runtime@1.1.4':
-    resolution: {integrity: sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow==}
+  '@napi-rs/wasm-runtime@1.1.6':
+    resolution: {integrity: sha512-ZLv/JdUfkvOy9eCnnBaGfiO+XimbjebAeO+MRQqD/B+FR1tnRN0tpKSJHRbE8sFfS6aqsXZ67TQjfwfsxULVbg==}
     peerDependencies:
       '@emnapi/core': ^1.7.1
       '@emnapi/runtime': ^1.7.1
 
-  '@oxc-project/types@0.130.0':
-    resolution: {integrity: sha512-ibD2usx9JRu7f5pu2tMKMI4cpA4NgXJQoYRP4pQ7Pxmn1l6k/53qWtQWZayhYy3X4QZkt90Ot+mJEaeXouio6Q==}
+  '@oxc-project/types@0.139.0':
+    resolution: {integrity: sha512-r9gHphtCs+1M7J0pw6Sn/hh/Wpa/iQrOOkrNAlVLF/gHq+/CJmHIWKKUUhdWjcD6CIa8idarspCsASiXCXvFUw==}
 
   '@quansync/fs@1.0.0':
     resolution: {integrity: sha512-4TJ3DFtlf1L5LDMaM6CanJ/0lckGNtJcMjQ1NAV6zDmA0tEHKZtxNKin8EgPaVX1YzljbxckyT2tJrpQKAtngQ==}
 
-  '@rolldown/binding-android-arm64@1.0.1':
-    resolution: {integrity: sha512-fJI3I0r3C3Oj/zdBCpaCmBRZYf07xpaq4yCfDDoSFm+beWNzbIl26puW8RraUdugoJw/95zerNOn6jasAhzSmg==}
+  '@rolldown/binding-android-arm64@1.1.5':
+    resolution: {integrity: sha512-lZg8fqIv2v7FF237bwMgzGZEJvGL79/s5knJ/i6FmsGF4XXlzccZ4jb+TrFIxtSSxFtIpdsgrPZeMk1I9AFcyQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [android]
 
-  '@rolldown/binding-darwin-arm64@1.0.1':
-    resolution: {integrity: sha512-cKnAhWEsV7TPcA/5EAteDp6KcJZBQ2G+BqE7zayMMi7kMvwRsbv7WT9aOnn0WNl4SKEIf43vjS31iUPu80nzXg==}
+  '@rolldown/binding-darwin-arm64@1.1.5':
+    resolution: {integrity: sha512-51Bnx9pNiMRKSUNtBfySkNJ9vMU9Hh3I1ozDd6gyPPYzaXCfnptUcEZxXGYFn+ul2dtcMUiqGR1Yai2K10uoTw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [darwin]
 
-  '@rolldown/binding-darwin-x64@1.0.1':
-    resolution: {integrity: sha512-YKrVwQjIRBPo+5G/u03wGjbdy4q7pyzCe93DK9VJ7zkVmeg8LJ7GbgsiHWdR4xSoe4CAXRD7Bcjgbtr64bkXNg==}
+  '@rolldown/binding-darwin-x64@1.1.5':
+    resolution: {integrity: sha512-Tm+gbfC0aHu1tBA/JvKQh32S0K6YgCHkiAF4/W6xX0K0RmNuc94VeK419dJoE65R5aRxmo+noZQSWrAMF6yb6g==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [darwin]
 
-  '@rolldown/binding-freebsd-x64@1.0.1':
-    resolution: {integrity: sha512-z/oBsREo46SsFqBwYtFe0kpJeBijAT48O/WXLI4suiCLBkr03RTtTJMCzSdDd2znlh8VJizL09XVkQgk8IZonw==}
+  '@rolldown/binding-freebsd-x64@1.1.5':
+    resolution: {integrity: sha512-JMzDKCCXq93YccG5gz3hvOs1oXRKAf0XYpfOS88e+wZrC8Iugj6j68867vrYZkvpDDpKn/KoKORThmchMpF6TA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [freebsd]
 
-  '@rolldown/binding-linux-arm-gnueabihf@1.0.1':
-    resolution: {integrity: sha512-ik8q7GM11zxvYxFc2PeDcT6TBvhCQMaUxfph/M5l9sKuTs/Sjg3L+Byw0F7w0ZVLBZmx30P+gG0ECzzN+MFcmQ==}
+  '@rolldown/binding-linux-arm-gnueabihf@1.1.5':
+    resolution: {integrity: sha512-uML21j2K5TfPGutKxub+M+nLjZIrWjXQ5Grx4lCe/nimTj9B4L63zHpjXLl4y0L3mcm2htEQIb06oCG/szerNw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm]
     os: [linux]
 
-  '@rolldown/binding-linux-arm64-gnu@1.0.1':
-    resolution: {integrity: sha512-QoSx2EkyrrdZ6kcyE8stqZ62t0Yra8Fs5ia9lOxJrh6TMQJK7gQKmscdTHf7pOXKREKrVwOtJcQG3qVSfc866A==}
+  '@rolldown/binding-linux-arm64-gnu@1.1.5':
+    resolution: {integrity: sha512-navSiuTMogvnQoZoM/v+l3ZWo50/NTwSHSzheABx/RCnmUPaKwq9qSo4Br2OYRs21+Fz8uFqITZM3H4opOB0/Q==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
     libc: [glibc]
 
-  '@rolldown/binding-linux-arm64-musl@1.0.1':
-    resolution: {integrity: sha512-uwNwFpwKeNiZawfAWBgg0VIztPTV3ihhh1vV334h9ivnNLorxnQMU6Fz8wG1Zb4Qh9LC1/MkcyT3YlDXG3Rsgg==}
+  '@rolldown/binding-linux-arm64-musl@1.1.5':
+    resolution: {integrity: sha512-lAryqH7IteztmCXQXk0etKj4wBQ7Gx5S6LjKhsgp9zb8I5bsuvU/2llH1hDQcjsFeqIsovMVN339/8pUDDBXxA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
     libc: [musl]
 
-  '@rolldown/binding-linux-ppc64-gnu@1.0.1':
-    resolution: {integrity: sha512-zY1bul7OWr7DFBiJ++wofXvnr8B45ce3QsQUhKrIhXsygAh7bTkwyeM1bi1a2g5C/yC/N8TZyGDEoMfm/l9mpg==}
+  '@rolldown/binding-linux-ppc64-gnu@1.1.5':
+    resolution: {integrity: sha512-fsK/sNBnxzBlL4O1JNrZakVQxPspqpED5dLtNsZS9oOKmtSpdNIzxH2kkol5HYTWJN47sE20ztMJPxfZ89qGOg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ppc64]
     os: [linux]
     libc: [glibc]
 
-  '@rolldown/binding-linux-s390x-gnu@1.0.1':
-    resolution: {integrity: sha512-0frlsT/f4Ft6I7SMESTKnF3cZsdicQn1dCMkF/jT9wDLE+gGoiQfv1nmT9e+s7s/fekvvy6tZM2jHvI2tkbJDQ==}
+  '@rolldown/binding-linux-s390x-gnu@1.1.5':
+    resolution: {integrity: sha512-gLYb4BIadlfTOYT5gO503n8zQjXflgzpD0FcyKh0Mzx3rqCZKnHoJWV9xe1KXUJ5lx2JfcSHr/mhzS0PC/McAA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [s390x]
     os: [linux]
     libc: [glibc]
 
-  '@rolldown/binding-linux-x64-gnu@1.0.1':
-    resolution: {integrity: sha512-XABVmGp9Tg0WspTVvwduTc4fpqy6JnAUrSQe6OuyqD/03nI7r0O9OWUkMIwFrjKAIqolvqoA4ZrJppgwE0Gxmw==}
+  '@rolldown/binding-linux-x64-gnu@1.1.5':
+    resolution: {integrity: sha512-FjcpEKUyJygHgs1o50VYNvkt5+7Le/VEdYt0AkRpkL33MnyQfwr8l5mXwMmfmTbyMPr5vJLC+8/Gd9gXnwU1QQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
     libc: [glibc]
 
-  '@rolldown/binding-linux-x64-musl@1.0.1':
-    resolution: {integrity: sha512-bV4fzswuzVcKD90o/VM6QqKxnxlDq0g2BISDLNVmxrnhpv1DDbyPhCIjYfvzYLV+MvkKKnQt2Q6AO86SEBULUQ==}
+  '@rolldown/binding-linux-x64-musl@1.1.5':
+    resolution: {integrity: sha512-Me+PfPI2TMeOQk0gYWfLQZtTktrmzbr8cDboqX83XKc7UrgAi55gF+2dUkWdxd19n55Essp2yeca+O9N5rBxHg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
     libc: [musl]
 
-  '@rolldown/binding-openharmony-arm64@1.0.1':
-    resolution: {integrity: sha512-/Mh0Zhq3OP7fVs0kcQHZP6lZEthMGTaSf8UBQYSFEZDWGXXlEC+nJ6EqenaK2t4LBXMe3A+K/G2BVXXdtOr4PQ==}
+  '@rolldown/binding-openharmony-arm64@1.1.5':
+    resolution: {integrity: sha512-yc5WrLzXks6zCQfn9Oxr8pORKyl/pF+QjHmW/Qx3qu0oyrrNC+y2JLTU1E2rcWYAmzlnqngWXHQjy51VzW70Vw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [openharmony]
 
-  '@rolldown/binding-wasm32-wasi@1.0.1':
-    resolution: {integrity: sha512-+1xc9X45l8ufsBAm6Gjvx2qDRIY9lTVt0cgWNcJ+1gdhXvkbxePA60yRTwSTuXL09CMhyJmjpV7E3NoyxbqFQQ==}
+  '@rolldown/binding-wasm32-wasi@1.1.5':
+    resolution: {integrity: sha512-VbQGPX2b4r48TAMIM2cjgluIM1HYutm4pcTEJsle7iEP7sB1dFqtPLBVbdLAZCxy1txCcPxf4QFf4v8uvltPqA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [wasm32]
 
-  '@rolldown/binding-win32-arm64-msvc@1.0.1':
-    resolution: {integrity: sha512-1D+UqZdfnuR+Jy1GgMJwi85bD40H21uNmOPRWQhw4oRSuolZ/B5rixZ45DK2KXOTCvmVCecauWgEhbw8bI7tOw==}
+  '@rolldown/binding-win32-arm64-msvc@1.1.5':
+    resolution: {integrity: sha512-gHv82k63z4qpV5+Q1y/12KrK0ltWBukVDI8nZcbT7Tt/ZlOIVwppazneq0F93oDxTo3IgAMEDIoQh3E2n6mVsw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [win32]
 
-  '@rolldown/binding-win32-x64-msvc@1.0.1':
-    resolution: {integrity: sha512-INAycaWuhlOK3wk4mRHGsdgwYWmd9cChdPdE9bwWmy6rn9VqVNYNFGhOdXrofXUxwHIncSiPNb8tNm8knDVIeQ==}
+  '@rolldown/binding-win32-x64-msvc@1.1.5':
+    resolution: {integrity: sha512-tTZuDBPw85tEN5PQi1pnEBzDy0Z49HtScLAbD5t6hyeU92A95pRWaSMw1GZZi/RwgSgUIl0xrSlXIT/9QzvYSA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [win32]
@@ -298,14 +260,11 @@ packages:
   '@rolldown/pluginutils@1.0.1':
     resolution: {integrity: sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==}
 
-  '@sinclair/typebox@0.34.49':
-    resolution: {integrity: sha512-brySQQs7Jtn0joV8Xh9ZV/hZb9Ozb0pmazDIASBkYKCjXrXU3mpcFahmK/z4YDhGkQvP9mWJbVyahdtU5wQA+A==}
+  '@sinclair/typebox@0.34.50':
+    resolution: {integrity: sha512-ydBWw0G6WFwWHzh9RK4B5c690UkreOG0llq0r+DaI7LgKgxigf8mhHzIPI3S0850g1BPkq/zpuCfrq4QFgUlTQ==}
 
-  '@tybys/wasm-util@0.10.2':
-    resolution: {integrity: sha512-RoBvJ2X0wuKlWFIjrwffGw1IqZHKQqzIchKaadZZfnNpsAYp2mM0h36JtPCjNDAHGgYez/15uMBpfGwchhiMgg==}
-
-  '@types/estree@1.0.9':
-    resolution: {integrity: sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==}
+  '@tybys/wasm-util@0.10.3':
+    resolution: {integrity: sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg==}
 
   '@types/istanbul-lib-coverage@2.0.6':
     resolution: {integrity: sha512-2QF/t/auWm0lsy8XtKVPG19v3sSOQlJe/YHZgfjb/KBBHOGSV+J2q/S671rcq9uTBrLAXmZpqJiaQbMT+zNU1w==}
@@ -319,11 +278,8 @@ packages:
   '@types/jest@30.0.0':
     resolution: {integrity: sha512-XTYugzhuwqWjws0CVz8QpM36+T+Dz5mTEBKhNs/esGLnCIlGdRy+Dq78NRjd7ls7r8BC8ZRMOrKlkO1hU0JOwA==}
 
-  '@types/jsesc@2.5.1':
-    resolution: {integrity: sha512-9VN+6yxLOPLOav+7PwjZbxiID2bVaeq0ED4qSQmdQTdjnXJSaCVKTR58t15oqH1H5t8Ng2ZX1SabJVoN9Q34bw==}
-
-  '@types/node@25.7.0':
-    resolution: {integrity: sha512-z+pdZyxE+RTQE9AcboAZCb4otwcrvgHD+GlBpPgn0emDVt0ohrTMhAwlr2Wd9nZ+nihhYFxO2pThz3C5qSu2Eg==}
+  '@types/node@26.1.1':
+    resolution: {integrity: sha512-nxAkRSVkN1Y0JC1W8ky/fTfkGsMmcrRsbx+3XoZE+rMOX71kLYTV7fLXpqud1GpbpP5TuffXFqfX7fH2GgZREw==}
 
   '@types/stack-utils@2.0.3':
     resolution: {integrity: sha512-9aEbYZ3TbYMznPdcdr3SmIrLXwC/AKZXQeCf9Pgao5CKb8CyHuEX5jzWPTkvregvhRJHcpRO6BFoGW9ycaOkYw==}
@@ -333,6 +289,251 @@ packages:
 
   '@types/yargs@17.0.35':
     resolution: {integrity: sha512-qUHkeCyQFxMXg79wQfTtfndEC+N9ZZg76HJftDJp+qH2tV7Gj4OJi7l+PiWwJ+pWtW8GwSmqsDj/oymhrTWXjg==}
+
+  '@typescript/typescript-aix-ppc64@7.0.2':
+    resolution: {integrity: sha512-MTKKkWB7p/0E9xi1d1tHtZ5PiLkGEMIq88pK2CubZjOsLtYTLqhgIgi6zepFa+9GHZ6h05NMCkQxGKiPXMxXtQ==}
+    engines: {node: '>=16.20.0'}
+    cpu: [ppc64]
+    os: [aix]
+
+  '@typescript/typescript-darwin-arm64@7.0.2':
+    resolution: {integrity: sha512-gowzar9MwS/aRWp6f3a4KUqzRjAZjOsmGNCM6LcTgXum+dBfgsBVMN+AgvOCCbguXyick6LJhpBszxMebJ8syA==}
+    engines: {node: '>=16.20.0'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@typescript/typescript-darwin-x64@7.0.2':
+    resolution: {integrity: sha512-SZ9xZInqApNlNGc9s0W1VSsktYSOe9cFqNOIqmN1Gs8SmkjKZYFt017G4VwPxASInODuAdbTW7sXiFUf893RgA==}
+    engines: {node: '>=16.20.0'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@typescript/typescript-freebsd-arm64@7.0.2':
+    resolution: {integrity: sha512-W5NH4y/J0plIIS5b2xvTEkU7JFxyqdMAOgf+Ilhl0vHQXKO5dZoxd+C/jEtq56c4F3wk71RB4BMRQ2XdI+bwYQ==}
+    engines: {node: '>=16.20.0'}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@typescript/typescript-freebsd-x64@7.0.2':
+    resolution: {integrity: sha512-UMGDx5sTpzNw3WiPebH7l90IWfJggEd+egHt/q6p7/Cm3zqoV7VxkGXt+3DxPIw8CcmvAB0j3sVVfbhX+M4Tpw==}
+    engines: {node: '>=16.20.0'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@typescript/typescript-linux-arm64@7.0.2':
+    resolution: {integrity: sha512-Qh4eU4/y3yDjnfjjyPYihMj5/ODIlmt+Bzu17OI+fiSRDW57QmU5SiN63exPRNJPKUzcc1INa1NXdrJ+MqHjUQ==}
+    engines: {node: '>=16.20.0'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@typescript/typescript-linux-arm@7.0.2':
+    resolution: {integrity: sha512-gffT3xPz9sR7j/YJExkyPntrI0P2EP9XbOyWzth2/Gs0RstK+90RBcO0ncXoXy/beYll1SXw846Nf2zdnEz0QQ==}
+    engines: {node: '>=16.20.0'}
+    cpu: [arm]
+    os: [linux]
+
+  '@typescript/typescript-linux-loong64@7.0.2':
+    resolution: {integrity: sha512-uEHck9i8hoAzXPiYRib1O7miOnz23SxIeVl6F4LXox+qov1K35jHcEW6VHKvZI+pyvl7fZEP4MCU5LYvIq1GuQ==}
+    engines: {node: '>=16.20.0'}
+    cpu: [loong64]
+    os: [linux]
+
+  '@typescript/typescript-linux-mips64el@7.0.2':
+    resolution: {integrity: sha512-R4KvAMnE43W5Qeqb0Ly56O3mWMWIAgsMyz36DCaycd5nbg/9kzm0liw3JocfRqyJY0KPmzFjbswozXyW0DnIYA==}
+    engines: {node: '>=16.20.0'}
+    cpu: [mips64el]
+    os: [linux]
+
+  '@typescript/typescript-linux-ppc64@7.0.2':
+    resolution: {integrity: sha512-DORx5b3sd/4S7eayxm4FQv+A7CrkUIGRaHiwI8oiHTAI1fAPWhF4J0vAlkC8biAlHSVVwxMQ3tjZ2/DVbnQiiA==}
+    engines: {node: '>=16.20.0'}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@typescript/typescript-linux-riscv64@7.0.2':
+    resolution: {integrity: sha512-wf0jqEDOjrPRnKwYRyyJDRo11KMbvMFrU+q4zqKyChODBzvlkbhNQfKvLxQCcwTpdDaXSHZTVuh0JoCrKCUMHQ==}
+    engines: {node: '>=16.20.0'}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@typescript/typescript-linux-s390x@7.0.2':
+    resolution: {integrity: sha512-IkwJc3L7yhytWd/ewjyxNDfOmswCm9GWMJT/ue/dU4aZNbwZeYAetq42VyLmsmSjvoX7z74X6ZaYCtzAr0EuGw==}
+    engines: {node: '>=16.20.0'}
+    cpu: [s390x]
+    os: [linux]
+
+  '@typescript/typescript-linux-x64@7.0.2':
+    resolution: {integrity: sha512-EYdf2cNg7rgCWJnxCdJ+F3V39O8ihb37eHAu1LK8oAFizgTQbPOK7zHHXbPt8rX24COqODXeI3sIf0fCXG7H/A==}
+    engines: {node: '>=16.20.0'}
+    cpu: [x64]
+    os: [linux]
+
+  '@typescript/typescript-netbsd-arm64@7.0.2':
+    resolution: {integrity: sha512-+polYF4MF04aPpO5FTkHran9yUQDSXqy5GiSDKpsll5jy3l3+g9QLhpf39T+ePtefhXLOGrLl0QIjkQP6VnelA==}
+    engines: {node: '>=16.20.0'}
+    cpu: [arm64]
+    os: [netbsd]
+
+  '@typescript/typescript-netbsd-x64@7.0.2':
+    resolution: {integrity: sha512-8YIT0EHM/3dq10ZOVF/A7pc/YSMtbcecct4rWtexrnSCHOPcpC2KTLXfTCR6vDpnSiY12heNb1GiN/wu+T/FyA==}
+    engines: {node: '>=16.20.0'}
+    cpu: [x64]
+    os: [netbsd]
+
+  '@typescript/typescript-openbsd-arm64@7.0.2':
+    resolution: {integrity: sha512-APT8+ClYnuYm1u9+kgGXoMj2VzWzcymwh2gNSQVySHfkRDGOTVkoWLjCmOQSaO+PoqQ57B0flRp9SA+7GnnkzQ==}
+    engines: {node: '>=16.20.0'}
+    cpu: [arm64]
+    os: [openbsd]
+
+  '@typescript/typescript-openbsd-x64@7.0.2':
+    resolution: {integrity: sha512-yX7s+Q0Dln0Dt9tEzZsAjXXR/+ytBM7AlglaqyeMPxQszJ1JhlJdZ6jLA+IzldHtflX81em7lDao1xXu+aRRkg==}
+    engines: {node: '>=16.20.0'}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@typescript/typescript-sunos-x64@7.0.2':
+    resolution: {integrity: sha512-dLJDGaLZ1D4HPQn62u1n8mBDkJREwMsAkCdkwd4Ieqw+x3TUyTsqY0YiBCtE6H6OzzgGk3iuZ3vFWRS+E8/d1g==}
+    engines: {node: '>=16.20.0'}
+    cpu: [x64]
+    os: [sunos]
+
+  '@typescript/typescript-win32-arm64@7.0.2':
+    resolution: {integrity: sha512-Gyl1Vy6OsWesLzmq+EP0Fb7b4Nid5232AvcA2SFcdYreldpNtYFFofPjnt62y9hQy7VTaZp65ICJjuAQRaVcIQ==}
+    engines: {node: '>=16.20.0'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@typescript/typescript-win32-x64@7.0.2':
+    resolution: {integrity: sha512-0BQ3HkAHHlKLSp1qRvf3SUhGpGsDuhB/jgFw75guyqbxJqEaS0Cw/VFO8i2nHglJUzQCRtMMR/IBAKE3ETMC4g==}
+    engines: {node: '>=16.20.0'}
+    cpu: [x64]
+    os: [win32]
+
+  '@yuku-codegen/binding-darwin-arm64@0.5.44':
+    resolution: {integrity: sha512-mpZc7hrjl/qxcbEMS6vVLE0lO4DjiXCvrp3gYbZ58bbmsSxSGCTlOCA0lpeLXAKOZxe0ZrVoqKteaewFF2Vbuw==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@yuku-codegen/binding-darwin-x64@0.5.44':
+    resolution: {integrity: sha512-PCt776PnGtnQYimxk18IyvPf/BQ6CNU95W+6eaoQfeME8ra+7v3pNNoTAmLfSveUC9KZPaoajR9NqkKfEVjA2Q==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@yuku-codegen/binding-freebsd-x64@0.5.44':
+    resolution: {integrity: sha512-5MNu1R4ysytPLMdl1UlGyjgAbUdT8fguW/QRo+pyEymbuWRN5n8JEHCFpm4AsWdP61fStagSpPDJcwN+mwC9Lg==}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@yuku-codegen/binding-linux-arm-gnu@0.5.44':
+    resolution: {integrity: sha512-xbP2qQ7/h6ZZKeckCiI2osB5SE5PBfLb4uzIfO1BSTX+9rlBKTqomxDaCib7aPf2X1CXMiIq+i7AK1EhBa5a7A==}
+    cpu: [arm]
+    os: [linux]
+    libc: [glibc]
+
+  '@yuku-codegen/binding-linux-arm-musl@0.5.44':
+    resolution: {integrity: sha512-gmXKMCpgkUm5PllGMKBMoBmqgbTQkx+S85eE46LctuwTSKS/K7u65NE6t4zk6cLDvZpV67enycKXBORWn6q7xA==}
+    cpu: [arm]
+    os: [linux]
+    libc: [musl]
+
+  '@yuku-codegen/binding-linux-arm64-gnu@0.5.44':
+    resolution: {integrity: sha512-eOoejNUtnHs1/TMn4wryOAG/TarvlOqSZtRPeS56liBKp/GVQSirqTM9AITSGPLSdK1u7fZWMdj5IOEoJp3ruw==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@yuku-codegen/binding-linux-arm64-musl@0.5.44':
+    resolution: {integrity: sha512-xTzrhEMy1mdv5+SbJPPlwqlMrhXGPntE2f12TLi+dNPXhif4iXCGJpoh8pV9nwZFE/cq1ITuTnjIfTFj/PifzA==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@yuku-codegen/binding-linux-x64-gnu@0.5.44':
+    resolution: {integrity: sha512-2bvgIU4P+f4q18grdHoGnt9L6XlAciq/8GWpM06fmwj8qqruS8qwwwZXBk3/0U2+IHGv9pXRR8GtSXzl5n/blg==}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@yuku-codegen/binding-linux-x64-musl@0.5.44':
+    resolution: {integrity: sha512-EzX5hWK0MmU4fbqY9coc5PJ0y0LYjrBdAF7mjSyetdK/yWRGBfHi9nh0dUJ0lqb47653hxB8/r9byfYgg6ecbA==}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@yuku-codegen/binding-win32-arm64@0.5.44':
+    resolution: {integrity: sha512-/ajGFWcOLGtmVUdxWKXDW6Ixtez68xxtmd2l95xNg8Lzs4aqbV2cy0Ns2Bzg9vjHsgDIooQlLXHpWh6HsHcy6w==}
+    cpu: [arm64]
+    os: [win32]
+
+  '@yuku-codegen/binding-win32-x64@0.5.44':
+    resolution: {integrity: sha512-geuJQ7FKI8YUtBgW8w72ChMfMvYy3gSytACxB4HOkylsoutrhH6lUNYHk1ny/p8u8t47NGxktpnzVJzI8IzJkA==}
+    cpu: [x64]
+    os: [win32]
+
+  '@yuku-parser/binding-darwin-arm64@0.5.44':
+    resolution: {integrity: sha512-EXSW5w1YOIMyxu53MFxP43gTDeHlQueOjk8AEI9tuLF5976bDq3MXuIgzQvZKPVAirxGZu8+ANVXH1WcAH1G6A==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@yuku-parser/binding-darwin-x64@0.5.44':
+    resolution: {integrity: sha512-pJBHsKxqR/nPwwaXgkkYTVo3G9dJ/AXhWsYyKyadU1zLg9gGfVwVTMehqwwutMCONDsLqOmEv/UqItmhpVsQJw==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@yuku-parser/binding-freebsd-x64@0.5.44':
+    resolution: {integrity: sha512-fOqYX5BQML94uj9hd3a+LlBNz54OoDm6l+wgUIZ8UUkOBfPV+w2lux1jj9FKXT85wwjDOFhgZ/XQYSEDK/N9mA==}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@yuku-parser/binding-linux-arm-gnu@0.5.44':
+    resolution: {integrity: sha512-kA2jRNh2cbbHDbhBN9IR8CnYI4UZHNQg0OVz6+V16Ph5VlLYpfv/6GdCmvQQoTGAnhFlbQiRoQys03ey91FTew==}
+    cpu: [arm]
+    os: [linux]
+    libc: [glibc]
+
+  '@yuku-parser/binding-linux-arm-musl@0.5.44':
+    resolution: {integrity: sha512-TQ82L8c5Lxl3HBOmw0uGfCcsyw0mp7DVGwCuW24OdDWak6BKaumvB8/Ep1llPOvhk5xgSFB7fsqgh6sIwkNRew==}
+    cpu: [arm]
+    os: [linux]
+    libc: [musl]
+
+  '@yuku-parser/binding-linux-arm64-gnu@0.5.44':
+    resolution: {integrity: sha512-o6up+m/MsoMEtq6h4JTzmzKOvH9o3o41vK8oiok0LOZoPOFOqOSqC+N5V2ArD1O54m5LUq6ErghAbGWiPsMsqg==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@yuku-parser/binding-linux-arm64-musl@0.5.44':
+    resolution: {integrity: sha512-3XZoiHhtrjWKgk7CJC/sGzk1TE57SDPYzOFXUg6CZrigRZ+c0Q5ItzJpyAvhzlxv5ruNRYiuGvFbaRSIDnp2BA==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@yuku-parser/binding-linux-x64-gnu@0.5.44':
+    resolution: {integrity: sha512-7KYCySZI6cjsdeiiIwvviDfJFd4Xj5gjNBzm9akUpwxRXNwaHHuEq2yGkVdGqj3BT6dJsiNhJIhtS6k7/HJdFA==}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@yuku-parser/binding-linux-x64-musl@0.5.44':
+    resolution: {integrity: sha512-SLU/nXwOjET2XlOiO984sAzCloiWw0+JdcWpGzXLz3JQWbdiblxWC9cIvB0fCtKdDhX1mIutKNEH+RRRJADYcQ==}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@yuku-parser/binding-win32-arm64@0.5.44':
+    resolution: {integrity: sha512-LGmaJtB2mVqPD7Gu/RKAu9aIVxlaKPOgKB8RPHeFFD5Tf/apCiWZix1tkBjdOAo9cVEAoR9qnVHE6zJ+OG0drQ==}
+    cpu: [arm64]
+    os: [win32]
+
+  '@yuku-parser/binding-win32-x64@0.5.44':
+    resolution: {integrity: sha512-2i0FTklLuhBIgILvtEQ3IN3J4qaTMKlxptseWNrz4F5mimL9UpQFUniVju9OOInwP2O1vgLdZn8EBjEXGNCHmg==}
+    cpu: [x64]
+    os: [win32]
+
+  '@yuku-toolchain/types@0.5.43':
+    resolution: {integrity: sha512-kSpvPntnXw5+lYjO71ffBEnQ5ycQ74KGIYknh0TS4xeyCuBkOqxyJumxZkMhLBBUCLjDAbx2+Icnr3Zh4ftjpQ==}
 
   ansi-regex@5.0.1:
     resolution: {integrity: sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==}
@@ -346,16 +547,12 @@ packages:
     resolution: {integrity: sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==}
     engines: {node: '>=10'}
 
-  ansis@4.3.0:
-    resolution: {integrity: sha512-44mvgtPvohuU/70DdY5Oz2AIrLJ9k6/5x4KmoSvPwO+5Moijo0+N9D0fKbbYZQWP1hNm5CpOf+E01jhxG/r8xg==}
+  ansis@4.3.1:
+    resolution: {integrity: sha512-BJ8/l4R5LRE7hW9WdSuGYrLSHi2ynxeFpDFbH0K/CgNeY/tyhk+vO6TYxXC5r5CpUhNVX310xzPsN/H9lCdfOA==}
     engines: {node: '>=14'}
 
   assert@2.1.0:
     resolution: {integrity: sha512-eLHpSK/Y4nhMJ07gDaAzoX/XAKS8PSaojml3M0DM4JpV1LAi5JOJ/p6H/XWrl8L+DzVEvVCW1z3vWAaB9oTsQw==}
-
-  ast-kit@3.0.0-beta.1:
-    resolution: {integrity: sha512-trmleAnZ2PxN/loHWVhhx1qeOHSRXq4TDsBBxq3GqeJitfk3+jTQ+v/C1km/KYq9M7wKqCewMh+/NAvVH7m+bw==}
-    engines: {node: '>=20.19.0'}
 
   ast-types@0.15.2:
     resolution: {integrity: sha512-c27loCv9QkZinsa5ProX751khO9DJl/AcB5c2KNtA6NRvHKS0PgLfcftz72KVq504vB0Gku5s2kUZzDBvQWvHg==}
@@ -368,8 +565,8 @@ packages:
   asynckit@0.4.0:
     resolution: {integrity: sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==}
 
-  auto-changelog@2.5.1:
-    resolution: {integrity: sha512-vpG10KkmGaeMHwvCK2G+4j6e1+ZxVnhDadHnbG0sFuiB2fzAPIybicp5782btmf4+UGfHklVCUcHWZyN3YiXKg==}
+  auto-changelog@2.6.0:
+    resolution: {integrity: sha512-jJgUkuWXQ7fPLPXOMQk/XSSmy7KvzpzhjJa6w660dq1KTEez/GW2CPckBra3jMMMMpcwxp84bOslo29qRCewzA==}
     engines: {node: '>= 10'}
     hasBin: true
 
@@ -381,11 +578,8 @@ packages:
     resolution: {integrity: sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==}
     engines: {node: 18 || 20 || >=22}
 
-  birpc@4.0.0:
-    resolution: {integrity: sha512-LShSxJP0KTmd101b6DRyGBj57LZxSDYWKitQNW/mi8GRMvZb078Uf9+pveax1DrVL89vm7mWe+TovdI/UDOuPw==}
-
-  brace-expansion@5.0.6:
-    resolution: {integrity: sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==}
+  brace-expansion@5.0.7:
+    resolution: {integrity: sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==}
     engines: {node: 18 || 20 || >=22}
 
   cac@7.0.0:
@@ -512,9 +706,6 @@ packages:
     resolution: {integrity: sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==}
     engines: {node: '>=4'}
     hasBin: true
-
-  estree-walker@3.0.3:
-    resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
 
   expect@30.4.1:
     resolution: {integrity: sha512-PMARsyh/JtqC20HoGqlFcIlQAyqUtW4PlI1rup1uhYJtKuwAjbvWi3GQMAn+STdHum/dk8xrKfUM1+5SAwpolA==}
@@ -682,11 +873,6 @@ packages:
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
 
-  jsesc@3.1.0:
-    resolution: {integrity: sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==}
-    engines: {node: '>=6'}
-    hasBin: true
-
   jsonrepair@3.13.2:
     resolution: {integrity: sha512-Leuly0nbM4R+S5SVJk3VHfw1oxnlEK9KygdZvfUtEtTawNDyzB4qa1xWTmFt1aeoA7sXZkVTRuIixJ8bAvqVUg==}
     hasBin: true
@@ -697,8 +883,8 @@ packages:
   lodash@4.17.23:
     resolution: {integrity: sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==}
 
-  lru-cache@11.3.6:
-    resolution: {integrity: sha512-Gf/KoL3C/MlI7Bt0PGI9I+TeTC/I6r/csU58N4BSNc4lppLBeKsOdFYkK+dX0ABDUMJNfCHTyPpzwwO21Awd3A==}
+  lru-cache@11.5.2:
+    resolution: {integrity: sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==}
     engines: {node: 20 || >=22}
 
   luxon@3.7.2:
@@ -753,8 +939,9 @@ packages:
     resolution: {integrity: sha512-nK28WOo+QIjBkDduTINE4JkF/UJJKyf2EJxvJKfblDpyg0Q+pkOHNTL0Qwy6NP6FhE/EnzV73BxxqcJaXY9anw==}
     engines: {node: '>= 0.4'}
 
-  obug@2.1.1:
-    resolution: {integrity: sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==}
+  obug@2.1.3:
+    resolution: {integrity: sha512-9miFgM2OFba7hB+pRgvtV84pYTBaoTHohvmIgiRt6dRIzbwEOIaNaP+dIlGs2fNFoB0SeISs0Jz5WFVRid6Xyg==}
+    engines: {node: '>=12.20.0'}
 
   package-json-from-dist@1.0.1:
     resolution: {integrity: sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==}
@@ -768,14 +955,11 @@ packages:
     resolution: {integrity: sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==}
     engines: {node: 18 || 20 || >=22}
 
-  pathe@2.0.3:
-    resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
-
   picocolors@1.1.1:
     resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
 
-  picomatch@4.0.4:
-    resolution: {integrity: sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==}
+  picomatch@4.0.5:
+    resolution: {integrity: sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==}
     engines: {node: '>=12'}
 
   possible-typed-array-names@1.1.0:
@@ -792,8 +976,8 @@ packages:
   react-is@18.3.1:
     resolution: {integrity: sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==}
 
-  react-is@19.2.6:
-    resolution: {integrity: sha512-XjBR15BhXuylgWGuslhDKqlSayuqvqBX91BP8pauG8kd1zY8kotkNWbXksTCNRarse4kuGbe2kIY05ARtwNIvw==}
+  react-is@19.2.7:
+    resolution: {integrity: sha512-kZFnouyVv7eP/Phmrlo9FK+zcAdriZJvzxXHF1Sl1P377WSGe2G/JxVolhTrB/jeV47lKImhNUsijjHAAbcl/A==}
 
   recast@0.22.0:
     resolution: {integrity: sha512-5AAx+mujtXijsEavc5lWXBPQqrM4+Dl5qNH96N2aNeuJFUzpiiToKPsxQD/zAIJHspz7zz0maX0PCtCTFVlixQ==}
@@ -815,15 +999,15 @@ packages:
     engines: {node: 20 || >=22}
     hasBin: true
 
-  rolldown-plugin-dts@0.25.0:
-    resolution: {integrity: sha512-GE3uDZgUuA9l6g+1u928TRmadd5IVhaWiwpWast2kCyLv9tYJJCC6E5HHkV0HGmwC5ZL73xh12/PRZI+KZ2vdQ==}
-    engines: {node: ^22.18.0 || >=24.0.0}
+  rolldown-plugin-dts@0.27.4:
+    resolution: {integrity: sha512-z1uz1gH2sJ55i6JY/xi3q7gsI5CPthefDp5HYXnBlrkN1L3K4tx+gyAQO3Udt69ASWItWKwXJ55nKQq2HCMVfA==}
+    engines: {node: ^22.18.0 || >=24.11.0}
     peerDependencies:
       '@ts-macro/tsc': ^0.3.6
       '@typescript/native-preview': '>=7.0.0-dev.20260325.1'
       rolldown: ^1.0.0
-      typescript: ^6.0.0
-      vue-tsc: ~3.2.0
+      typescript: ^5.0.0 || ^6.0.0 || ^7.0.0
+      vue-tsc: ~3.2.0 || ~3.3.0
     peerDependenciesMeta:
       '@ts-macro/tsc':
         optional: true
@@ -834,8 +1018,8 @@ packages:
       vue-tsc:
         optional: true
 
-  rolldown@1.0.1:
-    resolution: {integrity: sha512-X0KQHljNnEkWNqqiz9zJrGunh1B0HgOxLXvnFpCOcadzcy5qohZ3tqMEUg00vncoRovXuK3ZqCT9KnnKzoInFQ==}
+  rolldown@1.1.5:
+    resolution: {integrity: sha512-t9z29cJjXf/vxQ8dyhCSpt6H6aSwHTk8cT5I3iy6SMXuFpk5mB6PL6XfC8PCwrPTx93udwKUm9HRteAlTGBLiA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
 
@@ -847,8 +1031,8 @@ packages:
     resolution: {integrity: sha512-6R3J5M4AcbtLUdZmRv2SygeVaM7IhrLXu9BmnOGmmACak8fiUtOsYNWUS4uK7upbmHIBbLBeFeI//477BKLBzA==}
     engines: {node: '>=11.0.0'}
 
-  semver@7.8.0:
-    resolution: {integrity: sha512-AcM7dV/5ul4EekoQ29Agm5vri8JNqRyj39o0qpX6vDF2GZrtutZl5RwgD1XnZjiTAfncsJhMI48QQH3sN87YNA==}
+  semver@7.8.5:
+    resolution: {integrity: sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==}
     engines: {node: '>=10'}
     hasBin: true
 
@@ -880,12 +1064,12 @@ packages:
     resolution: {integrity: sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==}
     engines: {node: '>=8'}
 
-  tinyexec@1.1.2:
-    resolution: {integrity: sha512-dAqSqE/RabpBKI8+h26GfLq6Vb3JVXs30XYQjdMjaj/c2tS8IYYMbIzP599KtRj7c57/wYApb3QjgRgXmrCukA==}
+  tinyexec@1.2.4:
+    resolution: {integrity: sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg==}
     engines: {node: '>=18'}
 
-  tinyglobby@0.2.16:
-    resolution: {integrity: sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==}
+  tinyglobby@0.2.17:
+    resolution: {integrity: sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==}
     engines: {node: '>=12.0.0'}
 
   title-case@3.0.3:
@@ -900,14 +1084,14 @@ packages:
     resolution: {integrity: sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==}
     hasBin: true
 
-  tsdown@0.22.0:
-    resolution: {integrity: sha512-FgW0hHb27nGQA/+F3d5+U9wKXkfilk9DVkc5+7x/ZqF03g+Hoz/eeApT32jqxATt9eRoR+1jxk7MUMON+O4CXw==}
-    engines: {node: ^22.18.0 || >=24.0.0}
+  tsdown@0.22.4:
+    resolution: {integrity: sha512-3a5FsNL2fH2jw3ozvFUuPMBgS0xXjX9wpZShHyB4klXelVhyaNw5Q5WA9TPCNeoGYpRZEc4OZdMx5wT4Fkma3A==}
+    engines: {node: ^22.18.0 || >=24.11.0}
     hasBin: true
     peerDependencies:
       '@arethetypeswrong/core': ^0.18.1
-      '@tsdown/css': 0.22.0
-      '@tsdown/exe': 0.22.0
+      '@tsdown/css': 0.22.4
+      '@tsdown/exe': 0.22.4
       '@vitejs/devtools': '*'
       publint: ^0.3.8
       tsx: '*'
@@ -937,9 +1121,9 @@ packages:
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
 
-  typescript@5.9.3:
-    resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
-    engines: {node: '>=14.17'}
+  typescript@7.0.2:
+    resolution: {integrity: sha512-8FYau96o3NKOhbjKi/qNvG/W5jhzxkbdm5sj9AbZ/5T5sWqn3hJgLfGx27sRKZWTvyzCP8dLRBTf5tBTSRVUNA==}
+    engines: {node: '>=16.20.0'}
     hasBin: true
 
   uglify-js@3.19.3:
@@ -950,11 +1134,11 @@ packages:
   unconfig-core@7.5.0:
     resolution: {integrity: sha512-Su3FauozOGP44ZmKdHy2oE6LPjk51M/TRRjHv2HNCWiDvfvCoxC2lno6jevMA91MYAdCdwP05QnWdWpSbncX/w==}
 
-  undici-types@7.21.0:
-    resolution: {integrity: sha512-w9IMgQrz4O0YN1LtB7K5P63vhlIOvC7opSmouCJ+ZywlPAlO9gIkJ+otk6LvGpAs2wg4econaCz3TvQ9xPoyuQ==}
+  undici-types@8.3.0:
+    resolution: {integrity: sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==}
 
-  unrun@0.3.0:
-    resolution: {integrity: sha512-5xw2AIVS2WR9Lqhz76qDIQLxipKRidf7Nq+Iz5SZ8shk1OmRlxnc6FyI/1Q2m99WLj6cbqaKFdESfWE99KPzlA==}
+  unrun@0.3.1:
+    resolution: {integrity: sha512-onIck/oNnCaytwths1ZVp1LK2Gq2hPoyFhiHebObuUXqR3S0uHuLLaBK8K6mRRgV7Ptip8AnNvaUsgzwWwBZuA==}
     engines: {node: ^22.13.0 || >=24.0.0}
     hasBin: true
     peerDependencies:
@@ -1002,90 +1186,75 @@ packages:
     resolution: {integrity: sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==}
     engines: {node: '>=12'}
 
+  yuku-ast@0.1.7:
+    resolution: {integrity: sha512-2RiMEWv500TixY5rJy6OZd4fSy9WYZKWh6gGbIJ7y7vAGcuCugWOWwOLGaQcRZrXcPUfqtLtvpaJ3SdXtWlhKA==}
+
+  yuku-codegen@0.5.44:
+    resolution: {integrity: sha512-0rhtgWGz+bR3Pe7xqJ5E4VqxI1vqNtkeJRkeXM0Qd3tgldYClQipxa9bRZyuNOOfk0Ri02scrjnkoAHM16/f2g==}
+
+  yuku-parser@0.5.44:
+    resolution: {integrity: sha512-mAhpQZ/bXjxZmKiGUqEWskC9mZTcTBv6/fdzVdzdjM6XuD1DP3IavdLVWdM39L9ewK9vS9OtJmaKNeWgRzpy0w==}
+
   zod@3.25.67:
     resolution: {integrity: sha512-idA2YXwpCdqUSKRCACDE6ItZD9TZzy3OZMtpfLoh6oPR47lipysRrJfjzMqFxQ3uJuUPyUeWe1r9vLH33xO/Qw==}
 
 snapshots:
 
-  '@babel/code-frame@7.29.0':
+  '@babel/code-frame@7.29.7':
     dependencies:
-      '@babel/helper-validator-identifier': 7.28.5
+      '@babel/helper-validator-identifier': 7.29.7
       js-tokens: 4.0.0
       picocolors: 1.1.1
 
-  '@babel/generator@8.0.0-rc.4':
-    dependencies:
-      '@babel/parser': 8.0.0-rc.4
-      '@babel/types': 8.0.0-rc.5
-      '@jridgewell/gen-mapping': 0.3.13
-      '@jridgewell/trace-mapping': 0.3.31
-      '@types/jsesc': 2.5.1
-      jsesc: 3.1.0
+  '@babel/helper-validator-identifier@7.29.7': {}
 
-  '@babel/helper-string-parser@8.0.0-rc.5': {}
-
-  '@babel/helper-validator-identifier@7.28.5': {}
-
-  '@babel/helper-validator-identifier@8.0.0-rc.4': {}
-
-  '@babel/helper-validator-identifier@8.0.0-rc.5': {}
-
-  '@babel/parser@8.0.0-rc.4':
-    dependencies:
-      '@babel/types': 8.0.0-rc.5
-
-  '@babel/types@8.0.0-rc.5':
-    dependencies:
-      '@babel/helper-string-parser': 8.0.0-rc.5
-      '@babel/helper-validator-identifier': 8.0.0-rc.5
-
-  '@biomejs/biome@2.4.15':
+  '@biomejs/biome@2.5.3':
     optionalDependencies:
-      '@biomejs/cli-darwin-arm64': 2.4.15
-      '@biomejs/cli-darwin-x64': 2.4.15
-      '@biomejs/cli-linux-arm64': 2.4.15
-      '@biomejs/cli-linux-arm64-musl': 2.4.15
-      '@biomejs/cli-linux-x64': 2.4.15
-      '@biomejs/cli-linux-x64-musl': 2.4.15
-      '@biomejs/cli-win32-arm64': 2.4.15
-      '@biomejs/cli-win32-x64': 2.4.15
+      '@biomejs/cli-darwin-arm64': 2.5.3
+      '@biomejs/cli-darwin-x64': 2.5.3
+      '@biomejs/cli-linux-arm64': 2.5.3
+      '@biomejs/cli-linux-arm64-musl': 2.5.3
+      '@biomejs/cli-linux-x64': 2.5.3
+      '@biomejs/cli-linux-x64-musl': 2.5.3
+      '@biomejs/cli-win32-arm64': 2.5.3
+      '@biomejs/cli-win32-x64': 2.5.3
 
-  '@biomejs/cli-darwin-arm64@2.4.15':
+  '@biomejs/cli-darwin-arm64@2.5.3':
     optional: true
 
-  '@biomejs/cli-darwin-x64@2.4.15':
+  '@biomejs/cli-darwin-x64@2.5.3':
     optional: true
 
-  '@biomejs/cli-linux-arm64-musl@2.4.15':
+  '@biomejs/cli-linux-arm64-musl@2.5.3':
     optional: true
 
-  '@biomejs/cli-linux-arm64@2.4.15':
+  '@biomejs/cli-linux-arm64@2.5.3':
     optional: true
 
-  '@biomejs/cli-linux-x64-musl@2.4.15':
+  '@biomejs/cli-linux-x64-musl@2.5.3':
     optional: true
 
-  '@biomejs/cli-linux-x64@2.4.15':
+  '@biomejs/cli-linux-x64@2.5.3':
     optional: true
 
-  '@biomejs/cli-win32-arm64@2.4.15':
+  '@biomejs/cli-win32-arm64@2.5.3':
     optional: true
 
-  '@biomejs/cli-win32-x64@2.4.15':
+  '@biomejs/cli-win32-x64@2.5.3':
     optional: true
 
-  '@emnapi/core@1.10.0':
+  '@emnapi/core@1.11.1':
     dependencies:
-      '@emnapi/wasi-threads': 1.2.1
+      '@emnapi/wasi-threads': 1.2.2
       tslib: 2.8.1
     optional: true
 
-  '@emnapi/runtime@1.10.0':
+  '@emnapi/runtime@1.11.1':
     dependencies:
       tslib: 2.8.1
     optional: true
 
-  '@emnapi/wasi-threads@1.2.1':
+  '@emnapi/wasi-threads@1.2.2':
     dependencies:
       tslib: 2.8.1
     optional: true
@@ -1100,12 +1269,12 @@ snapshots:
 
   '@jest/pattern@30.4.0':
     dependencies:
-      '@types/node': 25.7.0
+      '@types/node': 26.1.1
       jest-regex-util: 30.4.0
 
   '@jest/schemas@30.4.1':
     dependencies:
-      '@sinclair/typebox': 0.34.49
+      '@sinclair/typebox': 0.34.50
 
   '@jest/types@30.4.1':
     dependencies:
@@ -1113,23 +1282,9 @@ snapshots:
       '@jest/schemas': 30.4.1
       '@types/istanbul-lib-coverage': 2.0.6
       '@types/istanbul-reports': 3.0.4
-      '@types/node': 25.7.0
+      '@types/node': 26.1.1
       '@types/yargs': 17.0.35
       chalk: 4.1.2
-
-  '@jridgewell/gen-mapping@0.3.13':
-    dependencies:
-      '@jridgewell/sourcemap-codec': 1.5.5
-      '@jridgewell/trace-mapping': 0.3.31
-
-  '@jridgewell/resolve-uri@3.1.2': {}
-
-  '@jridgewell/sourcemap-codec@1.5.5': {}
-
-  '@jridgewell/trace-mapping@0.3.31':
-    dependencies:
-      '@jridgewell/resolve-uri': 3.1.2
-      '@jridgewell/sourcemap-codec': 1.5.5
 
   '@n8n/errors@0.6.0':
     dependencies:
@@ -1158,78 +1313,76 @@ snapshots:
     dependencies:
       eslint-config-riot: 1.0.0
 
-  '@napi-rs/wasm-runtime@1.1.4(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)':
+  '@napi-rs/wasm-runtime@1.1.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)':
     dependencies:
-      '@emnapi/core': 1.10.0
-      '@emnapi/runtime': 1.10.0
-      '@tybys/wasm-util': 0.10.2
+      '@emnapi/core': 1.11.1
+      '@emnapi/runtime': 1.11.1
+      '@tybys/wasm-util': 0.10.3
     optional: true
 
-  '@oxc-project/types@0.130.0': {}
+  '@oxc-project/types@0.139.0': {}
 
   '@quansync/fs@1.0.0':
     dependencies:
       quansync: 1.0.0
 
-  '@rolldown/binding-android-arm64@1.0.1':
+  '@rolldown/binding-android-arm64@1.1.5':
     optional: true
 
-  '@rolldown/binding-darwin-arm64@1.0.1':
+  '@rolldown/binding-darwin-arm64@1.1.5':
     optional: true
 
-  '@rolldown/binding-darwin-x64@1.0.1':
+  '@rolldown/binding-darwin-x64@1.1.5':
     optional: true
 
-  '@rolldown/binding-freebsd-x64@1.0.1':
+  '@rolldown/binding-freebsd-x64@1.1.5':
     optional: true
 
-  '@rolldown/binding-linux-arm-gnueabihf@1.0.1':
+  '@rolldown/binding-linux-arm-gnueabihf@1.1.5':
     optional: true
 
-  '@rolldown/binding-linux-arm64-gnu@1.0.1':
+  '@rolldown/binding-linux-arm64-gnu@1.1.5':
     optional: true
 
-  '@rolldown/binding-linux-arm64-musl@1.0.1':
+  '@rolldown/binding-linux-arm64-musl@1.1.5':
     optional: true
 
-  '@rolldown/binding-linux-ppc64-gnu@1.0.1':
+  '@rolldown/binding-linux-ppc64-gnu@1.1.5':
     optional: true
 
-  '@rolldown/binding-linux-s390x-gnu@1.0.1':
+  '@rolldown/binding-linux-s390x-gnu@1.1.5':
     optional: true
 
-  '@rolldown/binding-linux-x64-gnu@1.0.1':
+  '@rolldown/binding-linux-x64-gnu@1.1.5':
     optional: true
 
-  '@rolldown/binding-linux-x64-musl@1.0.1':
+  '@rolldown/binding-linux-x64-musl@1.1.5':
     optional: true
 
-  '@rolldown/binding-openharmony-arm64@1.0.1':
+  '@rolldown/binding-openharmony-arm64@1.1.5':
     optional: true
 
-  '@rolldown/binding-wasm32-wasi@1.0.1':
+  '@rolldown/binding-wasm32-wasi@1.1.5':
     dependencies:
-      '@emnapi/core': 1.10.0
-      '@emnapi/runtime': 1.10.0
-      '@napi-rs/wasm-runtime': 1.1.4(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
+      '@emnapi/core': 1.11.1
+      '@emnapi/runtime': 1.11.1
+      '@napi-rs/wasm-runtime': 1.1.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)
     optional: true
 
-  '@rolldown/binding-win32-arm64-msvc@1.0.1':
+  '@rolldown/binding-win32-arm64-msvc@1.1.5':
     optional: true
 
-  '@rolldown/binding-win32-x64-msvc@1.0.1':
+  '@rolldown/binding-win32-x64-msvc@1.1.5':
     optional: true
 
   '@rolldown/pluginutils@1.0.1': {}
 
-  '@sinclair/typebox@0.34.49': {}
+  '@sinclair/typebox@0.34.50': {}
 
-  '@tybys/wasm-util@0.10.2':
+  '@tybys/wasm-util@0.10.3':
     dependencies:
       tslib: 2.8.1
     optional: true
-
-  '@types/estree@1.0.9': {}
 
   '@types/istanbul-lib-coverage@2.0.6': {}
 
@@ -1246,11 +1399,9 @@ snapshots:
       expect: 30.4.1
       pretty-format: 30.4.1
 
-  '@types/jsesc@2.5.1': {}
-
-  '@types/node@25.7.0':
+  '@types/node@26.1.1':
     dependencies:
-      undici-types: 7.21.0
+      undici-types: 8.3.0
 
   '@types/stack-utils@2.0.3': {}
 
@@ -1260,6 +1411,134 @@ snapshots:
     dependencies:
       '@types/yargs-parser': 21.0.3
 
+  '@typescript/typescript-aix-ppc64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-darwin-arm64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-darwin-x64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-freebsd-arm64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-freebsd-x64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-linux-arm64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-linux-arm@7.0.2':
+    optional: true
+
+  '@typescript/typescript-linux-loong64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-linux-mips64el@7.0.2':
+    optional: true
+
+  '@typescript/typescript-linux-ppc64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-linux-riscv64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-linux-s390x@7.0.2':
+    optional: true
+
+  '@typescript/typescript-linux-x64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-netbsd-arm64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-netbsd-x64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-openbsd-arm64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-openbsd-x64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-sunos-x64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-win32-arm64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-win32-x64@7.0.2':
+    optional: true
+
+  '@yuku-codegen/binding-darwin-arm64@0.5.44':
+    optional: true
+
+  '@yuku-codegen/binding-darwin-x64@0.5.44':
+    optional: true
+
+  '@yuku-codegen/binding-freebsd-x64@0.5.44':
+    optional: true
+
+  '@yuku-codegen/binding-linux-arm-gnu@0.5.44':
+    optional: true
+
+  '@yuku-codegen/binding-linux-arm-musl@0.5.44':
+    optional: true
+
+  '@yuku-codegen/binding-linux-arm64-gnu@0.5.44':
+    optional: true
+
+  '@yuku-codegen/binding-linux-arm64-musl@0.5.44':
+    optional: true
+
+  '@yuku-codegen/binding-linux-x64-gnu@0.5.44':
+    optional: true
+
+  '@yuku-codegen/binding-linux-x64-musl@0.5.44':
+    optional: true
+
+  '@yuku-codegen/binding-win32-arm64@0.5.44':
+    optional: true
+
+  '@yuku-codegen/binding-win32-x64@0.5.44':
+    optional: true
+
+  '@yuku-parser/binding-darwin-arm64@0.5.44':
+    optional: true
+
+  '@yuku-parser/binding-darwin-x64@0.5.44':
+    optional: true
+
+  '@yuku-parser/binding-freebsd-x64@0.5.44':
+    optional: true
+
+  '@yuku-parser/binding-linux-arm-gnu@0.5.44':
+    optional: true
+
+  '@yuku-parser/binding-linux-arm-musl@0.5.44':
+    optional: true
+
+  '@yuku-parser/binding-linux-arm64-gnu@0.5.44':
+    optional: true
+
+  '@yuku-parser/binding-linux-arm64-musl@0.5.44':
+    optional: true
+
+  '@yuku-parser/binding-linux-x64-gnu@0.5.44':
+    optional: true
+
+  '@yuku-parser/binding-linux-x64-musl@0.5.44':
+    optional: true
+
+  '@yuku-parser/binding-win32-arm64@0.5.44':
+    optional: true
+
+  '@yuku-parser/binding-win32-x64@0.5.44':
+    optional: true
+
+  '@yuku-toolchain/types@0.5.43': {}
+
   ansi-regex@5.0.1: {}
 
   ansi-styles@4.3.0:
@@ -1268,7 +1547,7 @@ snapshots:
 
   ansi-styles@5.2.0: {}
 
-  ansis@4.3.0: {}
+  ansis@4.3.1: {}
 
   assert@2.1.0:
     dependencies:
@@ -1277,12 +1556,6 @@ snapshots:
       object-is: 1.1.6
       object.assign: 4.1.7
       util: 0.12.5
-
-  ast-kit@3.0.0-beta.1:
-    dependencies:
-      '@babel/parser': 8.0.0-rc.4
-      estree-walker: 3.0.3
-      pathe: 2.0.3
 
   ast-types@0.15.2:
     dependencies:
@@ -1294,13 +1567,13 @@ snapshots:
 
   asynckit@0.4.0: {}
 
-  auto-changelog@2.5.1:
+  auto-changelog@2.6.0:
     dependencies:
       commander: 7.2.0
       handlebars: 4.7.9
       import-cwd: 3.0.0
       parse-github-url: 1.0.4
-      semver: 7.8.0
+      semver: 7.8.5
 
   available-typed-arrays@1.0.7:
     dependencies:
@@ -1308,9 +1581,7 @@ snapshots:
 
   balanced-match@4.0.4: {}
 
-  birpc@4.0.0: {}
-
-  brace-expansion@5.0.6:
+  brace-expansion@5.0.7:
     dependencies:
       balanced-match: 4.0.4
 
@@ -1417,10 +1688,6 @@ snapshots:
 
   esprima@4.0.1: {}
 
-  estree-walker@3.0.3:
-    dependencies:
-      '@types/estree': 1.0.9
-
   expect@30.4.1:
     dependencies:
       '@jest/expect-utils': 30.4.1
@@ -1430,9 +1697,9 @@ snapshots:
       jest-mock: 30.4.1
       jest-util: 30.4.1
 
-  fdir@6.5.0(picomatch@4.0.4):
+  fdir@6.5.0(picomatch@4.0.5):
     optionalDependencies:
-      picomatch: 4.0.4
+      picomatch: 4.0.5
 
   for-each@0.3.5:
     dependencies:
@@ -1578,13 +1845,13 @@ snapshots:
 
   jest-message-util@30.4.1:
     dependencies:
-      '@babel/code-frame': 7.29.0
+      '@babel/code-frame': 7.29.7
       '@jest/types': 30.4.1
       '@types/stack-utils': 2.0.3
       chalk: 4.1.2
       graceful-fs: 4.2.11
       jest-util: 30.4.1
-      picomatch: 4.0.4
+      picomatch: 4.0.5
       pretty-format: 30.4.1
       slash: 3.0.0
       stack-utils: 2.0.6
@@ -1592,7 +1859,7 @@ snapshots:
   jest-mock@30.4.1:
     dependencies:
       '@jest/types': 30.4.1
-      '@types/node': 25.7.0
+      '@types/node': 26.1.1
       jest-util: 30.4.1
 
   jest-regex-util@30.4.0: {}
@@ -1600,11 +1867,11 @@ snapshots:
   jest-util@30.4.1:
     dependencies:
       '@jest/types': 30.4.1
-      '@types/node': 25.7.0
+      '@types/node': 26.1.1
       chalk: 4.1.2
       ci-info: 4.4.0
       graceful-fs: 4.2.11
-      picomatch: 4.0.4
+      picomatch: 4.0.5
 
   jmespath@0.16.0: {}
 
@@ -1612,15 +1879,13 @@ snapshots:
 
   js-tokens@4.0.0: {}
 
-  jsesc@3.1.0: {}
-
   jsonrepair@3.13.2: {}
 
   jssha@3.3.1: {}
 
   lodash@4.17.23: {}
 
-  lru-cache@11.3.6: {}
+  lru-cache@11.5.2: {}
 
   luxon@3.7.2: {}
 
@@ -1640,7 +1905,7 @@ snapshots:
 
   minimatch@10.2.5:
     dependencies:
-      brace-expansion: 5.0.6
+      brace-expansion: 5.0.7
 
   minimist@1.2.8: {}
 
@@ -1689,7 +1954,7 @@ snapshots:
       has-symbols: 1.1.0
       object-keys: 1.1.1
 
-  obug@2.1.1: {}
+  obug@2.1.3: {}
 
   package-json-from-dist@1.0.1: {}
 
@@ -1697,14 +1962,12 @@ snapshots:
 
   path-scurry@2.0.2:
     dependencies:
-      lru-cache: 11.3.6
+      lru-cache: 11.5.2
       minipass: 7.1.3
-
-  pathe@2.0.3: {}
 
   picocolors@1.1.1: {}
 
-  picomatch@4.0.4: {}
+  picomatch@4.0.5: {}
 
   possible-typed-array-names@1.1.0: {}
 
@@ -1713,13 +1976,13 @@ snapshots:
       '@jest/schemas': 30.4.1
       ansi-styles: 5.2.0
       react-is-18: react-is@18.3.1
-      react-is-19: react-is@19.2.6
+      react-is-19: react-is@19.2.7
 
   quansync@1.0.0: {}
 
   react-is@18.3.1: {}
 
-  react-is@19.2.6: {}
+  react-is@19.2.7: {}
 
   recast@0.22.0:
     dependencies:
@@ -1740,42 +2003,40 @@ snapshots:
       glob: 13.0.6
       package-json-from-dist: 1.0.1
 
-  rolldown-plugin-dts@0.25.0(rolldown@1.0.1)(typescript@5.9.3):
+  rolldown-plugin-dts@0.27.4(rolldown@1.1.5)(typescript@7.0.2):
     dependencies:
-      '@babel/generator': 8.0.0-rc.4
-      '@babel/helper-validator-identifier': 8.0.0-rc.4
-      '@babel/parser': 8.0.0-rc.4
-      ast-kit: 3.0.0-beta.1
-      birpc: 4.0.0
       dts-resolver: 3.0.0
       get-tsconfig: 5.0.0-beta.5
-      obug: 2.1.1
-      rolldown: 1.0.1
+      obug: 2.1.3
+      rolldown: 1.1.5
+      yuku-ast: 0.1.7
+      yuku-codegen: 0.5.44
+      yuku-parser: 0.5.44
     optionalDependencies:
-      typescript: 5.9.3
+      typescript: 7.0.2
     transitivePeerDependencies:
       - oxc-resolver
 
-  rolldown@1.0.1:
+  rolldown@1.1.5:
     dependencies:
-      '@oxc-project/types': 0.130.0
+      '@oxc-project/types': 0.139.0
       '@rolldown/pluginutils': 1.0.1
     optionalDependencies:
-      '@rolldown/binding-android-arm64': 1.0.1
-      '@rolldown/binding-darwin-arm64': 1.0.1
-      '@rolldown/binding-darwin-x64': 1.0.1
-      '@rolldown/binding-freebsd-x64': 1.0.1
-      '@rolldown/binding-linux-arm-gnueabihf': 1.0.1
-      '@rolldown/binding-linux-arm64-gnu': 1.0.1
-      '@rolldown/binding-linux-arm64-musl': 1.0.1
-      '@rolldown/binding-linux-ppc64-gnu': 1.0.1
-      '@rolldown/binding-linux-s390x-gnu': 1.0.1
-      '@rolldown/binding-linux-x64-gnu': 1.0.1
-      '@rolldown/binding-linux-x64-musl': 1.0.1
-      '@rolldown/binding-openharmony-arm64': 1.0.1
-      '@rolldown/binding-wasm32-wasi': 1.0.1
-      '@rolldown/binding-win32-arm64-msvc': 1.0.1
-      '@rolldown/binding-win32-x64-msvc': 1.0.1
+      '@rolldown/binding-android-arm64': 1.1.5
+      '@rolldown/binding-darwin-arm64': 1.1.5
+      '@rolldown/binding-darwin-x64': 1.1.5
+      '@rolldown/binding-freebsd-x64': 1.1.5
+      '@rolldown/binding-linux-arm-gnueabihf': 1.1.5
+      '@rolldown/binding-linux-arm64-gnu': 1.1.5
+      '@rolldown/binding-linux-arm64-musl': 1.1.5
+      '@rolldown/binding-linux-ppc64-gnu': 1.1.5
+      '@rolldown/binding-linux-s390x-gnu': 1.1.5
+      '@rolldown/binding-linux-x64-gnu': 1.1.5
+      '@rolldown/binding-linux-x64-musl': 1.1.5
+      '@rolldown/binding-openharmony-arm64': 1.1.5
+      '@rolldown/binding-wasm32-wasi': 1.1.5
+      '@rolldown/binding-win32-arm64-msvc': 1.1.5
+      '@rolldown/binding-win32-x64-msvc': 1.1.5
 
   safe-regex-test@1.1.0:
     dependencies:
@@ -1785,7 +2046,7 @@ snapshots:
 
   sax@1.6.0: {}
 
-  semver@7.8.0: {}
+  semver@7.8.5: {}
 
   set-function-length@1.2.2:
     dependencies:
@@ -1818,12 +2079,12 @@ snapshots:
     dependencies:
       has-flag: 4.0.0
 
-  tinyexec@1.1.2: {}
+  tinyexec@1.2.4: {}
 
-  tinyglobby@0.2.16:
+  tinyglobby@0.2.17:
     dependencies:
-      fdir: 6.5.0(picomatch@4.0.4)
-      picomatch: 4.0.4
+      fdir: 6.5.0(picomatch@4.0.5)
+      picomatch: 4.0.5
 
   title-case@3.0.3:
     dependencies:
@@ -1835,26 +2096,26 @@ snapshots:
 
   tree-kill@1.2.2: {}
 
-  tsdown@0.22.0(typescript@5.9.3)(unrun@0.3.0):
+  tsdown@0.22.4(typescript@7.0.2)(unrun@0.3.1):
     dependencies:
-      ansis: 4.3.0
+      ansis: 4.3.1
       cac: 7.0.0
       defu: 6.1.7
       empathic: 2.0.1
       hookable: 6.1.1
       import-without-cache: 0.4.0
-      obug: 2.1.1
-      picomatch: 4.0.4
-      rolldown: 1.0.1
-      rolldown-plugin-dts: 0.25.0(rolldown@1.0.1)(typescript@5.9.3)
-      semver: 7.8.0
-      tinyexec: 1.1.2
-      tinyglobby: 0.2.16
+      obug: 2.1.3
+      picomatch: 4.0.5
+      rolldown: 1.1.5
+      rolldown-plugin-dts: 0.27.4(rolldown@1.1.5)(typescript@7.0.2)
+      semver: 7.8.5
+      tinyexec: 1.2.4
+      tinyglobby: 0.2.17
       tree-kill: 1.2.2
       unconfig-core: 7.5.0
     optionalDependencies:
-      typescript: 5.9.3
-      unrun: 0.3.0
+      typescript: 7.0.2
+      unrun: 0.3.1
     transitivePeerDependencies:
       - '@ts-macro/tsc'
       - '@typescript/native-preview'
@@ -1863,7 +2124,28 @@ snapshots:
 
   tslib@2.8.1: {}
 
-  typescript@5.9.3: {}
+  typescript@7.0.2:
+    optionalDependencies:
+      '@typescript/typescript-aix-ppc64': 7.0.2
+      '@typescript/typescript-darwin-arm64': 7.0.2
+      '@typescript/typescript-darwin-x64': 7.0.2
+      '@typescript/typescript-freebsd-arm64': 7.0.2
+      '@typescript/typescript-freebsd-x64': 7.0.2
+      '@typescript/typescript-linux-arm': 7.0.2
+      '@typescript/typescript-linux-arm64': 7.0.2
+      '@typescript/typescript-linux-loong64': 7.0.2
+      '@typescript/typescript-linux-mips64el': 7.0.2
+      '@typescript/typescript-linux-ppc64': 7.0.2
+      '@typescript/typescript-linux-riscv64': 7.0.2
+      '@typescript/typescript-linux-s390x': 7.0.2
+      '@typescript/typescript-linux-x64': 7.0.2
+      '@typescript/typescript-netbsd-arm64': 7.0.2
+      '@typescript/typescript-netbsd-x64': 7.0.2
+      '@typescript/typescript-openbsd-arm64': 7.0.2
+      '@typescript/typescript-openbsd-x64': 7.0.2
+      '@typescript/typescript-sunos-x64': 7.0.2
+      '@typescript/typescript-win32-arm64': 7.0.2
+      '@typescript/typescript-win32-x64': 7.0.2
 
   uglify-js@3.19.3:
     optional: true
@@ -1873,11 +2155,11 @@ snapshots:
       '@quansync/fs': 1.0.0
       quansync: 1.0.0
 
-  undici-types@7.21.0: {}
+  undici-types@8.3.0: {}
 
-  unrun@0.3.0:
+  unrun@0.3.1:
     dependencies:
-      rolldown: 1.0.1
+      rolldown: 1.1.5
 
   util@0.12.5:
     dependencies:
@@ -1927,5 +2209,41 @@ snapshots:
       string-width: 4.2.3
       y18n: 5.0.8
       yargs-parser: 21.1.1
+
+  yuku-ast@0.1.7:
+    dependencies:
+      '@yuku-toolchain/types': 0.5.43
+
+  yuku-codegen@0.5.44:
+    dependencies:
+      '@yuku-toolchain/types': 0.5.43
+    optionalDependencies:
+      '@yuku-codegen/binding-darwin-arm64': 0.5.44
+      '@yuku-codegen/binding-darwin-x64': 0.5.44
+      '@yuku-codegen/binding-freebsd-x64': 0.5.44
+      '@yuku-codegen/binding-linux-arm-gnu': 0.5.44
+      '@yuku-codegen/binding-linux-arm-musl': 0.5.44
+      '@yuku-codegen/binding-linux-arm64-gnu': 0.5.44
+      '@yuku-codegen/binding-linux-arm64-musl': 0.5.44
+      '@yuku-codegen/binding-linux-x64-gnu': 0.5.44
+      '@yuku-codegen/binding-linux-x64-musl': 0.5.44
+      '@yuku-codegen/binding-win32-arm64': 0.5.44
+      '@yuku-codegen/binding-win32-x64': 0.5.44
+
+  yuku-parser@0.5.44:
+    dependencies:
+      '@yuku-toolchain/types': 0.5.43
+    optionalDependencies:
+      '@yuku-parser/binding-darwin-arm64': 0.5.44
+      '@yuku-parser/binding-darwin-x64': 0.5.44
+      '@yuku-parser/binding-freebsd-x64': 0.5.44
+      '@yuku-parser/binding-linux-arm-gnu': 0.5.44
+      '@yuku-parser/binding-linux-arm-musl': 0.5.44
+      '@yuku-parser/binding-linux-arm64-gnu': 0.5.44
+      '@yuku-parser/binding-linux-arm64-musl': 0.5.44
+      '@yuku-parser/binding-linux-x64-gnu': 0.5.44
+      '@yuku-parser/binding-linux-x64-musl': 0.5.44
+      '@yuku-parser/binding-win32-arm64': 0.5.44
+      '@yuku-parser/binding-win32-x64': 0.5.44
 
   zod@3.25.67: {}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "strict": true,
     "module": "commonjs",
-    "moduleResolution": "node",
+    "moduleResolution": "bundler",
     "target": "es2019",
     "lib": ["es2019", "es2020", "es2022.error"],
     "types": ["node", "jest"],


### PR DESCRIPTION
## Summary

Syncs the codebase with the latest Resend API and updates all dev dependencies.

## New API Operations — Domain Claim

Three new operations added to the **Domains** resource to support the [Domain Claim flow](https://resend.com/docs/dashboard/domains/claim) (used when a domain is already verified by another team):

| Operation | HTTP | Endpoint |
|---|---|---|
| Claim | `POST` | `/domains/claim` |
| Get Claim | `GET` | `/domains/{id}/claim` |
| Verify Claim | `POST` | `/domains/{id}/claim/verify` |

**Workflow:**
1. Use **Claim** when domain creation fails because the domain belongs to another team — returns a TXT record to add to DNS
2. Add the TXT record to your DNS
3. Use **Verify Claim** to trigger the asynchronous ownership check
4. Poll **Get Claim** to follow the `status` until the domain is transferred

## Dependency Updates

| Package | Before | After |
|---|---|---|
| `@biomejs/biome` | 2.4.15 | 2.5.3 |
| `@types/node` | 25.7.0 | 26.1.1 |
| `auto-changelog` | 2.5.1 | 2.6.0 |
| `tsdown` | 0.22.0 | 0.22.4 |
| `typescript` | 5.9.3 | 7.0.2 |
| `unrun` | 0.3.0 | 0.3.1 |

## Config Fixes

- `tsconfig.json`: Updated `moduleResolution` from `"node"` → `"bundler"` (required for TypeScript 7, which removed the `node10` alias)
- `biome.json`: Migrated schema reference to 2.5.3