### PR TITLE
fix: OAuth2 disconnect auth helper + notice cleanup

### DIFF
--- a/nodes/Resend/actions/account/disconnect.operation.ts
+++ b/nodes/Resend/actions/account/disconnect.operation.ts
@@ -48,20 +48,24 @@ export async function execute(
   }
 
   try {
-    await this.helpers.httpRequest({
-      method: 'POST',
-      url: 'https://api.resend.com/oauth/revoke',
-      headers: {
-        'Content-Type': 'application/json',
-        'User-Agent': 'n8n-nodes-resend',
+    await this.helpers.httpRequestWithAuthentication.call(
+      this,
+      'resendOAuth2Api',
+      {
+        method: 'POST',
+        url: 'https://api.resend.com/oauth/revoke',
+        headers: {
+          'Content-Type': 'application/json',
+          'User-Agent': 'n8n-nodes-resend',
+        },
+        body: {
+          client_id: clientId,
+          token: refreshToken,
+          token_type_hint: 'refresh_token',
+        },
+        json: true,
       },
-      body: {
-        client_id: clientId,
-        token: refreshToken,
-        token_type_hint: 'refresh_token',
-      },
-      json: true,
-    });
+    );
   } catch (error) {
     handleResendApiError(this.getNode(), error, index);
   }

--- a/nodes/Resend/actions/domain/claim.operation.ts
+++ b/nodes/Resend/actions/domain/claim.operation.ts
@@ -8,19 +8,6 @@ import { apiRequest } from '../../transport';
 
 export const description: INodeProperties[] = [
   {
-    displayName:
-      'Use this operation when creating a domain fails because the domain is already verified by another team. Resend creates a placeholder domain and returns a TXT record to add to your DNS.',
-    name: 'claimDomainNotice',
-    type: 'notice',
-    default: '',
-    displayOptions: {
-      show: {
-        resource: ['domains'],
-        operation: ['claim'],
-      },
-    },
-  },
-  {
     displayName: 'Domain Name',
     name: 'domainName',
     type: 'string',

--- a/nodes/Resend/actions/domain/create.operation.ts
+++ b/nodes/Resend/actions/domain/create.operation.ts
@@ -8,19 +8,6 @@ import { apiRequest } from '../../transport';
 
 export const description: INodeProperties[] = [
   {
-    displayName:
-      'After adding a domain, you must configure DNS records (SPF, DKIM, DMARC) and verify the domain before sending emails.',
-    name: 'domainNotice',
-    type: 'notice',
-    default: '',
-    displayOptions: {
-      show: {
-        resource: ['domains'],
-        operation: ['create'],
-      },
-    },
-  },
-  {
     displayName: 'Domain Name',
     name: 'domainName',
     type: 'string',

--- a/nodes/Resend/actions/domain/createTrackingDomain.operation.ts
+++ b/nodes/Resend/actions/domain/createTrackingDomain.operation.ts
@@ -11,19 +11,6 @@ import {
 } from '../../utils/dynamicFields';
 
 export const description: INodeProperties[] = [
-  {
-    displayName:
-      'Custom tracking domains are currently in private alpha and only available to a limited number of users. APIs might change before GA. <a href="https://resend.com/contact">Contact us</a> if you\'re interested in testing this feature.',
-    name: 'trackingDomainAlphaNotice',
-    type: 'notice',
-    default: '',
-    displayOptions: {
-      show: {
-        resource: ['domains'],
-        operation: ['createTrackingDomain'],
-      },
-    },
-  },
   createDynamicIdField({
     fieldName: 'domainId',
     resourceName: 'domain',

--- a/nodes/Resend/actions/domain/deleteTrackingDomain.operation.ts
+++ b/nodes/Resend/actions/domain/deleteTrackingDomain.operation.ts
@@ -10,19 +10,6 @@ import {
 } from '../../utils/dynamicFields';
 
 export const description: INodeProperties[] = [
-  {
-    displayName:
-      'Custom tracking domains are currently in private alpha and only available to a limited number of users. APIs might change before GA. <a href="https://resend.com/contact">Contact us</a> if you\'re interested in testing this feature.',
-    name: 'trackingDomainAlphaNotice',
-    type: 'notice',
-    default: '',
-    displayOptions: {
-      show: {
-        resource: ['domains'],
-        operation: ['deleteTrackingDomain'],
-      },
-    },
-  },
   createDynamicIdField({
     fieldName: 'domainId',
     resourceName: 'domain',

--- a/nodes/Resend/actions/domain/getTrackingDomain.operation.ts
+++ b/nodes/Resend/actions/domain/getTrackingDomain.operation.ts
@@ -10,19 +10,6 @@ import {
 } from '../../utils/dynamicFields';
 
 export const description: INodeProperties[] = [
-  {
-    displayName:
-      'Custom tracking domains are currently in private alpha and only available to a limited number of users. APIs might change before GA. <a href="https://resend.com/contact">Contact us</a> if you\'re interested in testing this feature.',
-    name: 'trackingDomainAlphaNotice',
-    type: 'notice',
-    default: '',
-    displayOptions: {
-      show: {
-        resource: ['domains'],
-        operation: ['getTrackingDomain'],
-      },
-    },
-  },
   createDynamicIdField({
     fieldName: 'domainId',
     resourceName: 'domain',

--- a/nodes/Resend/actions/domain/listTrackingDomains.operation.ts
+++ b/nodes/Resend/actions/domain/listTrackingDomains.operation.ts
@@ -10,19 +10,6 @@ import {
 } from '../../utils/dynamicFields';
 
 export const description: INodeProperties[] = [
-  {
-    displayName:
-      'Custom tracking domains are currently in private alpha and only available to a limited number of users. APIs might change before GA. <a href="https://resend.com/contact">Contact us</a> if you\'re interested in testing this feature.',
-    name: 'trackingDomainAlphaNotice',
-    type: 'notice',
-    default: '',
-    displayOptions: {
-      show: {
-        resource: ['domains'],
-        operation: ['listTrackingDomains'],
-      },
-    },
-  },
   createDynamicIdField({
     fieldName: 'domainId',
     resourceName: 'domain',

--- a/nodes/Resend/actions/domain/verifyClaim.operation.ts
+++ b/nodes/Resend/actions/domain/verifyClaim.operation.ts
@@ -10,19 +10,6 @@ import {
 } from '../../utils/dynamicFields';
 
 export const description: INodeProperties[] = [
-  {
-    displayName:
-      'Add the TXT record returned by the Claim Domain operation before calling this. Resend checks the TXT record and runs ownership-safety checks before transferring the domain. Poll Get Domain Claim to follow the status.',
-    name: 'verifyClaimNotice',
-    type: 'notice',
-    default: '',
-    displayOptions: {
-      show: {
-        resource: ['domains'],
-        operation: ['verifyClaim'],
-      },
-    },
-  },
   createDynamicIdField({
     fieldName: 'domainId',
     resourceName: 'domain',

--- a/nodes/Resend/actions/domain/verifyTrackingDomain.operation.ts
+++ b/nodes/Resend/actions/domain/verifyTrackingDomain.operation.ts
@@ -10,19 +10,6 @@ import {
 } from '../../utils/dynamicFields';
 
 export const description: INodeProperties[] = [
-  {
-    displayName:
-      'Custom tracking domains are currently in private alpha and only available to a limited number of users. APIs might change before GA. <a href="https://resend.com/contact">Contact us</a> if you\'re interested in testing this feature.',
-    name: 'trackingDomainAlphaNotice',
-    type: 'notice',
-    default: '',
-    displayOptions: {
-      show: {
-        resource: ['domains'],
-        operation: ['verifyTrackingDomain'],
-      },
-    },
-  },
   createDynamicIdField({
     fieldName: 'domainId',
     resourceName: 'domain',

--- a/nodes/Resend/actions/email/send.operation.ts
+++ b/nodes/Resend/actions/email/send.operation.ts
@@ -18,19 +18,6 @@ import {
 
 export const description: INodeProperties[] = [
   {
-    displayName:
-      'Tips: The sender address must be from a verified domain. Scheduled emails cannot include attachments. Maximum 50 recipients per email.',
-    name: 'sendEmailNotice',
-    type: 'notice',
-    default: '',
-    displayOptions: {
-      show: {
-        resource: ['email'],
-        operation: ['send'],
-      },
-    },
-  },
-  {
     displayName: 'From',
     name: 'from',
     type: 'string',

--- a/nodes/Resend/actions/event/create.operation.ts
+++ b/nodes/Resend/actions/event/create.operation.ts
@@ -6,22 +6,7 @@ import type {
 } from 'n8n-workflow';
 import { apiRequest } from '../../transport';
 
-const BETA_NOTICE =
-  'Workflows and Events are currently in private alpha and only available to a limited number of users. APIs might change before GA. <a href="https://resend.com/contact">Contact us</a> if you\'re interested in testing this feature.';
-
 export const description: INodeProperties[] = [
-  {
-    displayName: BETA_NOTICE,
-    name: 'eventBetaNotice',
-    type: 'notice',
-    default: '',
-    displayOptions: {
-      show: {
-        resource: ['events'],
-        operation: ['create'],
-      },
-    },
-  },
   {
     displayName: 'Event Name',
     name: 'eventName',

--- a/nodes/Resend/actions/event/delete.operation.ts
+++ b/nodes/Resend/actions/event/delete.operation.ts
@@ -5,22 +5,7 @@ import type {
 } from 'n8n-workflow';
 import { apiRequest } from '../../transport';
 
-const BETA_NOTICE =
-  'Workflows and Events are currently in private alpha and only available to a limited number of users. APIs might change before GA. <a href="https://resend.com/contact">Contact us</a> if you\'re interested in testing this feature.';
-
 export const description: INodeProperties[] = [
-  {
-    displayName: BETA_NOTICE,
-    name: 'eventBetaNotice',
-    type: 'notice',
-    default: '',
-    displayOptions: {
-      show: {
-        resource: ['events'],
-        operation: ['delete'],
-      },
-    },
-  },
   {
     displayName: 'Event ID or Name',
     name: 'eventIdentifier',

--- a/nodes/Resend/actions/event/get.operation.ts
+++ b/nodes/Resend/actions/event/get.operation.ts
@@ -5,22 +5,7 @@ import type {
 } from 'n8n-workflow';
 import { apiRequest } from '../../transport';
 
-const BETA_NOTICE =
-  'Workflows and Events are currently in private alpha and only available to a limited number of users. APIs might change before GA. <a href="https://resend.com/contact">Contact us</a> if you\'re interested in testing this feature.';
-
 export const description: INodeProperties[] = [
-  {
-    displayName: BETA_NOTICE,
-    name: 'eventBetaNotice',
-    type: 'notice',
-    default: '',
-    displayOptions: {
-      show: {
-        resource: ['events'],
-        operation: ['get'],
-      },
-    },
-  },
   {
     displayName: 'Event ID or Name',
     name: 'eventIdentifier',

--- a/nodes/Resend/actions/event/list.operation.ts
+++ b/nodes/Resend/actions/event/list.operation.ts
@@ -5,23 +5,7 @@ import type {
 } from 'n8n-workflow';
 import { createListExecutionData, requestList } from '../../transport';
 
-const BETA_NOTICE =
-  'Workflows and Events are currently in private alpha and only available to a limited number of users. APIs might change before GA. <a href="https://resend.com/contact">Contact us</a> if you\'re interested in testing this feature.';
-
-export const description: INodeProperties[] = [
-  {
-    displayName: BETA_NOTICE,
-    name: 'eventBetaNotice',
-    type: 'notice',
-    default: '',
-    displayOptions: {
-      show: {
-        resource: ['events'],
-        operation: ['list'],
-      },
-    },
-  },
-];
+export const description: INodeProperties[] = [];
 
 export async function execute(
   this: IExecuteFunctions,

--- a/nodes/Resend/actions/event/send.operation.ts
+++ b/nodes/Resend/actions/event/send.operation.ts
@@ -6,22 +6,7 @@ import type {
 } from 'n8n-workflow';
 import { apiRequest } from '../../transport';
 
-const BETA_NOTICE =
-  'Workflows and Events are currently in private alpha and only available to a limited number of users. APIs might change before GA. <a href="https://resend.com/contact">Contact us</a> if you\'re interested in testing this feature.';
-
 export const description: INodeProperties[] = [
-  {
-    displayName: BETA_NOTICE,
-    name: 'eventBetaNotice',
-    type: 'notice',
-    default: '',
-    displayOptions: {
-      show: {
-        resource: ['events'],
-        operation: ['send'],
-      },
-    },
-  },
   {
     displayName: 'Event Name',
     name: 'eventName',

--- a/nodes/Resend/actions/event/update.operation.ts
+++ b/nodes/Resend/actions/event/update.operation.ts
@@ -6,22 +6,7 @@ import type {
 } from 'n8n-workflow';
 import { apiRequest } from '../../transport';
 
-const BETA_NOTICE =
-  'Workflows and Events are currently in private alpha and only available to a limited number of users. APIs might change before GA. <a href="https://resend.com/contact">Contact us</a> if you\'re interested in testing this feature.';
-
 export const description: INodeProperties[] = [
-  {
-    displayName: BETA_NOTICE,
-    name: 'eventBetaNotice',
-    type: 'notice',
-    default: '',
-    displayOptions: {
-      show: {
-        resource: ['events'],
-        operation: ['update'],
-      },
-    },
-  },
   {
     displayName: 'Event ID or Name',
     name: 'eventIdentifier',

--- a/nodes/Resend/actions/workflow/create.operation.ts
+++ b/nodes/Resend/actions/workflow/create.operation.ts
@@ -6,22 +6,7 @@ import type {
 } from 'n8n-workflow';
 import { apiRequest } from '../../transport';
 
-const BETA_NOTICE =
-  'Workflows are currently in private alpha and only available to a limited number of users. APIs might change before GA. <a href="https://resend.com/contact">Contact us</a> if you\'re interested in testing this feature.';
-
 export const description: INodeProperties[] = [
-  {
-    displayName: BETA_NOTICE,
-    name: 'workflowBetaNotice',
-    type: 'notice',
-    default: '',
-    displayOptions: {
-      show: {
-        resource: ['workflows'],
-        operation: ['create'],
-      },
-    },
-  },
   {
     displayName: 'Name',
     name: 'workflowName',

--- a/nodes/Resend/actions/workflow/delete.operation.ts
+++ b/nodes/Resend/actions/workflow/delete.operation.ts
@@ -5,22 +5,7 @@ import type {
 } from 'n8n-workflow';
 import { apiRequest } from '../../transport';
 
-const BETA_NOTICE =
-  'Workflows are currently in private alpha and only available to a limited number of users. APIs might change before GA. <a href="https://resend.com/contact">Contact us</a> if you\'re interested in testing this feature.';
-
 export const description: INodeProperties[] = [
-  {
-    displayName: BETA_NOTICE,
-    name: 'workflowBetaNotice',
-    type: 'notice',
-    default: '',
-    displayOptions: {
-      show: {
-        resource: ['workflows'],
-        operation: ['delete'],
-      },
-    },
-  },
   {
     displayName: 'Workflow ID',
     name: 'workflowId',

--- a/nodes/Resend/actions/workflow/get.operation.ts
+++ b/nodes/Resend/actions/workflow/get.operation.ts
@@ -5,22 +5,7 @@ import type {
 } from 'n8n-workflow';
 import { apiRequest } from '../../transport';
 
-const BETA_NOTICE =
-  'Workflows are currently in private alpha and only available to a limited number of users. APIs might change before GA. <a href="https://resend.com/contact">Contact us</a> if you\'re interested in testing this feature.';
-
 export const description: INodeProperties[] = [
-  {
-    displayName: BETA_NOTICE,
-    name: 'workflowBetaNotice',
-    type: 'notice',
-    default: '',
-    displayOptions: {
-      show: {
-        resource: ['workflows'],
-        operation: ['get'],
-      },
-    },
-  },
   {
     displayName: 'Workflow ID',
     name: 'workflowId',

--- a/nodes/Resend/actions/workflow/getRun.operation.ts
+++ b/nodes/Resend/actions/workflow/getRun.operation.ts
@@ -5,22 +5,7 @@ import type {
 } from 'n8n-workflow';
 import { apiRequest } from '../../transport';
 
-const BETA_NOTICE =
-  'Workflows are currently in private alpha and only available to a limited number of users. APIs might change before GA. <a href="https://resend.com/contact">Contact us</a> if you\'re interested in testing this feature.';
-
 export const description: INodeProperties[] = [
-  {
-    displayName: BETA_NOTICE,
-    name: 'workflowBetaNotice',
-    type: 'notice',
-    default: '',
-    displayOptions: {
-      show: {
-        resource: ['workflows'],
-        operation: ['getRun'],
-      },
-    },
-  },
   {
     displayName: 'Workflow ID',
     name: 'workflowId',

--- a/nodes/Resend/actions/workflow/getRunStep.operation.ts
+++ b/nodes/Resend/actions/workflow/getRunStep.operation.ts
@@ -5,22 +5,7 @@ import type {
 } from 'n8n-workflow';
 import { apiRequest } from '../../transport';
 
-const BETA_NOTICE =
-  'Workflows are currently in private alpha and only available to a limited number of users. APIs might change before GA. <a href="https://resend.com/contact">Contact us</a> if you\'re interested in testing this feature.';
-
 export const description: INodeProperties[] = [
-  {
-    displayName: BETA_NOTICE,
-    name: 'workflowBetaNotice',
-    type: 'notice',
-    default: '',
-    displayOptions: {
-      show: {
-        resource: ['workflows'],
-        operation: ['getRunStep'],
-      },
-    },
-  },
   {
     displayName: 'Workflow ID',
     name: 'workflowId',

--- a/nodes/Resend/actions/workflow/list.operation.ts
+++ b/nodes/Resend/actions/workflow/list.operation.ts
@@ -5,23 +5,7 @@ import type {
 } from 'n8n-workflow';
 import { createListExecutionData, requestList } from '../../transport';
 
-const BETA_NOTICE =
-  'Workflows are currently in private alpha and only available to a limited number of users. APIs might change before GA. <a href="https://resend.com/contact">Contact us</a> if you\'re interested in testing this feature.';
-
-export const description: INodeProperties[] = [
-  {
-    displayName: BETA_NOTICE,
-    name: 'workflowBetaNotice',
-    type: 'notice',
-    default: '',
-    displayOptions: {
-      show: {
-        resource: ['workflows'],
-        operation: ['list'],
-      },
-    },
-  },
-];
+export const description: INodeProperties[] = [];
 
 export async function execute(
   this: IExecuteFunctions,

--- a/nodes/Resend/actions/workflow/listRunSteps.operation.ts
+++ b/nodes/Resend/actions/workflow/listRunSteps.operation.ts
@@ -5,22 +5,7 @@ import type {
 } from 'n8n-workflow';
 import { apiRequest } from '../../transport';
 
-const BETA_NOTICE =
-  'Workflows are currently in private alpha and only available to a limited number of users. APIs might change before GA. <a href="https://resend.com/contact">Contact us</a> if you\'re interested in testing this feature.';
-
 export const description: INodeProperties[] = [
-  {
-    displayName: BETA_NOTICE,
-    name: 'workflowBetaNotice',
-    type: 'notice',
-    default: '',
-    displayOptions: {
-      show: {
-        resource: ['workflows'],
-        operation: ['listRunSteps'],
-      },
-    },
-  },
   {
     displayName: 'Workflow ID',
     name: 'workflowId',

--- a/nodes/Resend/actions/workflow/listRuns.operation.ts
+++ b/nodes/Resend/actions/workflow/listRuns.operation.ts
@@ -5,22 +5,7 @@ import type {
 } from 'n8n-workflow';
 import { apiRequest } from '../../transport';
 
-const BETA_NOTICE =
-  'Workflows are currently in private alpha and only available to a limited number of users. APIs might change before GA. <a href="https://resend.com/contact">Contact us</a> if you\'re interested in testing this feature.';
-
 export const description: INodeProperties[] = [
-  {
-    displayName: BETA_NOTICE,
-    name: 'workflowBetaNotice',
-    type: 'notice',
-    default: '',
-    displayOptions: {
-      show: {
-        resource: ['workflows'],
-        operation: ['listRuns'],
-      },
-    },
-  },
   {
     displayName: 'Workflow ID',
     name: 'workflowId',

--- a/nodes/Resend/actions/workflow/update.operation.ts
+++ b/nodes/Resend/actions/workflow/update.operation.ts
@@ -6,22 +6,7 @@ import type {
 } from 'n8n-workflow';
 import { apiRequest } from '../../transport';
 
-const BETA_NOTICE =
-  'Workflows are currently in private alpha and only available to a limited number of users. APIs might change before GA. <a href="https://resend.com/contact">Contact us</a> if you\'re interested in testing this feature.';
-
 export const description: INodeProperties[] = [
-  {
-    displayName: BETA_NOTICE,
-    name: 'workflowBetaNotice',
-    type: 'notice',
-    default: '',
-    displayOptions: {
-      show: {
-        resource: ['workflows'],
-        operation: ['update'],
-      },
-    },
-  },
   {
     displayName: 'Workflow ID',
     name: 'workflowId',

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "n8n-nodes-resend",
-  "version": "2.6.1",
+  "version": "2.6.2",
   "description": "Resend integration for n8n: Email, Broadcasts, Templates, Domains, Contacts, Segments, Topics, Webhooks, Workflows, Events, and more",
   "keywords": [
     "n8n-community-node-package",


### PR DESCRIPTION
## Summary
- Disconnect operation used `httpRequest` instead of `httpRequestWithAuthentication` for the OAuth2 revoke call — the request bypassed n8n's credential-authenticated request path. Now uses `httpRequestWithAuthentication` with the `resendOAuth2Api` credential.
- Removed notice-type UI elements that were duplicated across many operations (per review feedback that n8n is restricting overuse of notices): the beta notice repeated on every Events and Workflows operation, and the alpha notice repeated on every tracking-domain operation, plus the domain create/claim/verifyClaim tips and the email send tips notice.
- Bumped version to 2.6.2.

## Test plan
- [x] `npm run typecheck`
- [x] `npm run lint`
- [x] `npx tsdown` build succeeds