### PR TITLE
feat(email): support scheduled_at in batch send, allow multiple tags

### DIFF
--- a/nodes/Resend/actions/email/sendBatch.operation.ts
+++ b/nodes/Resend/actions/email/sendBatch.operation.ts
@@ -62,7 +62,10 @@ export const description: INodeProperties[] = [
                 displayName: 'Headers',
                 name: 'headers',
                 type: 'fixedCollection',
-                default: {},
+                default: { headers: [] },
+                typeOptions: {
+                  multipleValues: true,
+                },
                 options: [
                   {
                     name: 'headers',
@@ -96,10 +99,22 @@ export const description: INodeProperties[] = [
                   'Email address where replies should be sent. Can be different from the sender address.',
               },
               {
+                displayName: 'Scheduled At',
+                name: 'scheduledAt',
+                type: 'string',
+                default: '',
+                placeholder: 'in 1 hour',
+                description:
+                  'Schedule this email to be sent at a future time. Accepts natural language like "in 1 hour" or ISO 8601 format "2024-12-25T09:00:00Z". Each email in the batch can be scheduled independently.',
+              },
+              {
                 displayName: 'Tags',
                 name: 'tags',
                 type: 'fixedCollection',
-                default: {},
+                default: { tags: [] },
+                typeOptions: {
+                  multipleValues: true,
+                },
                 options: [
                   {
                     name: 'tags',
@@ -207,7 +222,10 @@ export const description: INodeProperties[] = [
             displayName: 'Template Variables',
             name: 'templateVariables',
             type: 'fixedCollection',
-            default: {},
+            default: { variables: [] },
+            typeOptions: {
+              multipleValues: true,
+            },
             description:
               'Key-value pairs to replace template placeholders. Keys must match the template variable names.',
             options: [
@@ -326,6 +344,7 @@ interface EmailInput {
     cc?: string;
     headers?: { headers: Array<{ name: string; value?: string }> };
     replyTo?: string;
+    scheduledAt?: string;
     tags?: { tags: Array<{ name: string; value?: string }> };
     topicId?: string;
   };
@@ -411,6 +430,12 @@ export async function execute(
     const topicId = additionalOptions.topicId;
     if (topicId) {
       emailObj.topic_id = topicId;
+    }
+
+    // Handle Scheduled At
+    const scheduledAt = additionalOptions.scheduledAt;
+    if (scheduledAt) {
+      emailObj.scheduled_at = scheduledAt;
     }
 
     // Handle content


### PR DESCRIPTION
## Summary

The Batch API now supports both `tags` and `scheduled_at` ([resend-node#1022](https://github.com/resend/resend-node/pull/1022), [changelog](https://resend.com/changelog/tags-for-batch-and-scheduled-emails)). This exposes both properly on the **Send Batch** operation.

- **Add a per-email "Scheduled At" option** mapping to `scheduled_at`. Accepts natural language (`in 1 hour`) or ISO 8601 (`2024-12-25T09:00:00Z`), matching the Send operation. Each email in the batch can be scheduled independently.
- **Set `multipleValues` on the `tags`, `headers` and `templateVariables` fixedCollections.** Tags were already wired up on the request side, but without `multipleValues` the UI only allowed a *single* entry each — so batch tags support was effectively limited to one tag per email. `send.operation.ts` already sets this; this brings Send Batch in line.

Attachments remain unsupported by the Batch API and are unchanged.

## Wire format

Verified against the resend-node tests in #1022 — `scheduledAt` serializes to `scheduled_at` per email object:

```json
[
  {
    "from": "admin@resend.com",
    "to": "user@resend.com",
    "subject": "Scheduled Email",
    "html": "<h1>Hello</h1>",
    "tags": [{ "name": "category", "value": "welcome" }],
    "scheduled_at": "in 1 hour"
  }
]
```

## Note on the API reference

The [Send Batch Emails docs page](https://resend.com/docs/api-reference/emails/send-batch-emails) still says *"The `attachments` and `scheduled_at` fields are not supported yet."* That line is now stale for `scheduled_at` and may be worth updating alongside this.

## Test plan

- [x] `pnpm run typecheck` passes
- [x] `pnpm run lint` passes
- [ ] Manual: send a batch with per-email tags + `scheduled_at`, confirm emails are scheduled and tags land in the dashboard
- [ ] Manual: confirm multiple tags/headers/variables can now be added per email in the UI