### PR TITLE
fix: respect OAuth2 authentication in all API requests

### DIFF
--- a/nodes/Resend/actions/email/send.operation.ts
+++ b/nodes/Resend/actions/email/send.operation.ts
@@ -7,6 +7,7 @@ import type {
 import { NodeOperationError } from 'n8n-workflow';
 import {
   buildTemplateSendVariables,
+  getCredentialType,
   handleResendApiError,
   normalizeEmailList,
   RESEND_API_BASE,
@@ -726,7 +727,7 @@ export async function execute(
   try {
     response = await this.helpers.httpRequestWithAuthentication.call(
       this,
-      'resendApi',
+      getCredentialType(this),
       {
         url: `${RESEND_API_BASE}/emails`,
         method: 'POST',

--- a/nodes/Resend/actions/email/sendBatch.operation.ts
+++ b/nodes/Resend/actions/email/sendBatch.operation.ts
@@ -7,6 +7,7 @@ import type {
 import { NodeOperationError } from 'n8n-workflow';
 import {
   buildTemplateSendVariables,
+  getCredentialType,
   handleResendApiError,
   normalizeEmailList,
   RESEND_API_BASE,
@@ -477,7 +478,7 @@ export async function execute(
   try {
     response = await this.helpers.httpRequestWithAuthentication.call(
       this,
-      'resendApi',
+      getCredentialType(this),
       {
         url: `${RESEND_API_BASE}/emails/batch`,
         method: 'POST',

--- a/nodes/Resend/methods/index.ts
+++ b/nodes/Resend/methods/index.ts
@@ -3,7 +3,11 @@ import type {
   INodeListSearchResult,
   INodePropertyOptions,
 } from 'n8n-workflow';
-import { handleResendApiError, RESEND_API_BASE } from '../transport';
+import {
+  getCredentialType,
+  handleResendApiError,
+  RESEND_API_BASE,
+} from '../transport';
 
 /** Resend list endpoints return `{ data: [...] }`. */
 type ResendListResponseBody<T> = { data?: T[] };
@@ -35,7 +39,7 @@ async function loadDropdownOptions(
     response =
       await loadOptionsFunctions.helpers.httpRequestWithAuthentication.call(
         loadOptionsFunctions,
-        'resendApi',
+        getCredentialType(loadOptionsFunctions),
         {
           url: `${RESEND_API_BASE}${endpoint}`,
           method: 'GET',
@@ -120,7 +124,7 @@ export async function getTemplateVariables(
   try {
     response = await this.helpers.httpRequestWithAuthentication.call(
       this,
-      'resendApi',
+      getCredentialType(this),
       {
         url: `${RESEND_API_BASE}/templates/${encodeURIComponent(normalizedTemplateId)}`,
         method: 'GET',
@@ -178,7 +182,7 @@ export async function getContacts(
   try {
     response = await this.helpers.httpRequestWithAuthentication.call(
       this,
-      'resendApi',
+      getCredentialType(this),
       {
         url: `${RESEND_API_BASE}/contacts`,
         method: 'GET',
@@ -230,7 +234,7 @@ export async function getWebhooks(
   try {
     response = await this.helpers.httpRequestWithAuthentication.call(
       this,
-      'resendApi',
+      getCredentialType(this),
       {
         url: `${RESEND_API_BASE}/webhooks`,
         method: 'GET',
@@ -276,7 +280,7 @@ export async function getEmails(
   try {
     response = await this.helpers.httpRequestWithAuthentication.call(
       this,
-      'resendApi',
+      getCredentialType(this),
       {
         url: `${RESEND_API_BASE}/emails`,
         method: 'GET',
@@ -325,7 +329,7 @@ export async function getReceivedEmails(
   try {
     response = await this.helpers.httpRequestWithAuthentication.call(
       this,
-      'resendApi',
+      getCredentialType(this),
       {
         url: `${RESEND_API_BASE}/emails/receiving`,
         method: 'GET',

--- a/nodes/Resend/transport/index.ts
+++ b/nodes/Resend/transport/index.ts
@@ -3,6 +3,7 @@ import type {
   IExecuteFunctions,
   IHttpRequestMethods,
   IHttpRequestOptions,
+  ILoadOptionsFunctions,
   INode,
   INodeExecutionData,
   JsonObject,
@@ -232,12 +233,22 @@ export function handleResendApiError(
 
 export const RESEND_API_BASE = 'https://api.resend.com';
 
-function getCredentialType(context: IExecuteFunctions): string {
-  const authentication = context.getNodeParameter(
-    'authentication',
-    0,
-    'apiKey',
-  ) as string;
+export function getCredentialType(
+  context: IExecuteFunctions | ILoadOptionsFunctions,
+): string {
+  let authentication: string;
+  if ('getInputData' in context) {
+    authentication = context.getNodeParameter(
+      'authentication',
+      0,
+      'apiKey',
+    ) as string;
+  } else {
+    authentication = context.getNodeParameter(
+      'authentication',
+      'apiKey',
+    ) as string;
+  }
   return authentication === 'oAuth2' ? 'resendOAuth2Api' : 'resendApi';
 }
 

--- a/nodes/Resend/utils/sendAndWait/utils.ts
+++ b/nodes/Resend/utils/sendAndWait/utils.ts
@@ -11,7 +11,11 @@ import {
   updateDisplayOptions,
   WAIT_INDEFINITELY,
 } from 'n8n-workflow';
-import { handleResendApiError, RESEND_API_BASE } from '../../transport';
+import {
+  getCredentialType,
+  handleResendApiError,
+  RESEND_API_BASE,
+} from '../../transport';
 import { limitWaitTimeOption } from './descriptions';
 import {
   ACTION_RECORDED_PAGE,
@@ -749,7 +753,7 @@ export async function sendResendEmail(
   try {
     await context.helpers.httpRequestWithAuthentication.call(
       context,
-      'resendApi',
+      getCredentialType(context),
       {
         url: `${RESEND_API_BASE}/emails`,
         method: 'POST',


### PR DESCRIPTION
## Summary
Fixes the HIGH finding by the n8n review team: **email send used a hardcoded `resendApi` credential, breaking OAuth2 users**. When Authentication was set to OAuth2, n8n tried to resolve the `resendApi` credential instead of `resendOAuth2Api` and the request failed.

The same hardcoded credential name existed in more places than the reported `send.operation.ts:729`, so all of them are fixed:

- `actions/email/send.operation.ts` (reported)
- `actions/email/sendBatch.operation.ts`
- `utils/sendAndWait/utils.ts` (`sendResendEmail`)
- `methods/index.ts` — all 6 loadOptions/listSearch requests (dropdowns were also broken for OAuth2 users)

## Changes
- `transport/index.ts`: `getCredentialType` is now exported and widened to accept `ILoadOptionsFunctions` as well as `IExecuteFunctions` (narrowed via `'getInputData' in context` since their `getNodeParameter` signatures differ).
- All call sites above now pass `getCredentialType(...)` instead of `'resendApi'`.
- `actions/account/disconnect.operation.ts` intentionally keeps `resendOAuth2Api` — that operation is OAuth2-only.

## Verification
- `pnpm lint` (biome) → clean
- `tsc --noEmit` → clean