### PR TITLE
chore(release): v2.6.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "n8n-nodes-resend",
-  "version": "2.6.3",
+  "version": "2.6.4",
   "description": "Resend integration for n8n: Email, Broadcasts, Templates, Domains, Contacts, Segments, Topics, Webhooks, Workflows, Events, and more",
   "keywords": [
     "n8n-community-node-package",


### PR DESCRIPTION
Version bump to `2.6.4`.

Since `2.6.3`:

- `feat(suppressions)`: Suppression resource (#127)
- `chore`: stripped code comments, added a vitest suite (448 tests), plus the `account` subtitle label and dependency cleanup (#128)