### PR TITLE
feat(account): add OAuth grant list and revoke operations

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ The table below shows which endpoints are currently implemented:
 
 | API Resource           | Endpoint              | Status  | Operations                                                                                                                                                    |
 | ---------------------- | --------------------- | ------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| **Account**            | `/oauth/revoke`       | ✅ Full | Disconnect (OAuth2 credential only)                                                                                                                           |
+| **Account**            | `/oauth`              | ✅ Full | Disconnect (OAuth2 credential only), List Grants, Revoke Grant                                                                                                |
 | **Email**              | `/emails`             | ✅ Full | Send, Send Batch, Send and Wait, List, Get, Update, Cancel, List Attachments, Get Attachment                                                                  |
 | **Receiving Emails**   | `/emails/receiving`   | ✅ Full | List, Get, List Attachments, Get Attachment                                                                                                                   |
 | **Domains**            | `/domains`            | ✅ Full | Create, List, Get, Update, Delete, Verify, Create Tracking Domain, Get Tracking Domain, List Tracking Domains, Delete Tracking Domain, Verify Tracking Domain |

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ The table below shows which endpoints are currently implemented:
 
 | API Resource           | Endpoint              | Status  | Operations                                                                                                                                                    |
 | ---------------------- | --------------------- | ------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| **Account**            | `/oauth`              | ✅ Full | Disconnect (OAuth2 credential only), List Grants, Revoke Grant                                                                                                |
+| **Account**            | `/oauth/revoke`, `/oauth/grants` | ✅ Full | Disconnect (OAuth2 credential only), List Grants, Revoke Grant                                                                                                |
 | **Email**              | `/emails`             | ✅ Full | Send, Send Batch, Send and Wait, List, Get, Update, Cancel, List Attachments, Get Attachment                                                                  |
 | **Receiving Emails**   | `/emails/receiving`   | ✅ Full | List, Get, List Attachments, Get Attachment                                                                                                                   |
 | **Domains**            | `/domains`            | ✅ Full | Create, List, Get, Update, Delete, Verify, Create Tracking Domain, Get Tracking Domain, List Tracking Domains, Delete Tracking Domain, Verify Tracking Domain |

--- a/nodes/Resend/Resend.node.ts
+++ b/nodes/Resend/Resend.node.ts
@@ -66,7 +66,7 @@ export class Resend implements INodeType {
     description:
       'Send emails, manage contacts, create broadcasts, handle templates, domains, segments, topics, and webhooks using the Resend email platform',
     subtitle:
-      '={{(() => { const resourceLabels = { account: "account", broadcasts: "broadcast", contacts: "contact", contactProperties: "contact property", domains: "domain", email: "email", logs: "log", receivingEmails: "received email", workflows: "workflow", events: "event", segments: "segment", suppressions: "suppression", templates: "template", topics: "topic", webhooks: "webhook" }; const operationLabels = { retrieve: "get", sendBatch: "send batch", listAttachments: "list attachments", getAttachment: "get attachment", addToSegment: "add to segment", listSegments: "list segments", removeFromSegment: "remove from segment", getTopics: "get topics", updateTopics: "update topics", listRuns: "list runs", getRun: "get run", listRunSteps: "list run steps", getRunStep: "get run step", batchAdd: "batch add", batchRemove: "batch remove" }; const resource = $parameter["resource"]; const operation = $parameter["operation"]; const resourceLabel = resourceLabels[resource] ?? resource; const operationLabel = operationLabels[operation] ?? operation; return operationLabel + ": " + resourceLabel; })() }}',
+      '={{(() => { const resourceLabels = { account: "account", broadcasts: "broadcast", contacts: "contact", contactProperties: "contact property", domains: "domain", email: "email", logs: "log", receivingEmails: "received email", workflows: "workflow", events: "event", segments: "segment", suppressions: "suppression", templates: "template", topics: "topic", webhooks: "webhook" }; const operationLabels = { retrieve: "get", sendBatch: "send batch", listAttachments: "list attachments", getAttachment: "get attachment", addToSegment: "add to segment", listSegments: "list segments", removeFromSegment: "remove from segment", getTopics: "get topics", updateTopics: "update topics", listRuns: "list runs", getRun: "get run", listRunSteps: "list run steps", getRunStep: "get run step", batchAdd: "batch add", batchRemove: "batch remove", listGrants: "list grants", revokeGrant: "revoke grant" }; const resource = $parameter["resource"]; const operation = $parameter["operation"]; const resourceLabel = resourceLabels[resource] ?? resource; const operationLabel = operationLabels[operation] ?? operation; return operationLabel + ": " + resourceLabel; })() }}',
     defaults: {
       name: 'Resend',
     },
@@ -124,7 +124,7 @@ export class Resend implements INodeType {
             name: 'Account',
             value: 'account',
             description:
-              'Manage the connected Resend OAuth2 account, such as disconnecting it',
+              'Manage the connected Resend OAuth2 account and its OAuth grants, such as disconnecting it or revoking a grant',
           },
           {
             name: 'Broadcast',

--- a/nodes/Resend/actions/account/execute.ts
+++ b/nodes/Resend/actions/account/execute.ts
@@ -1,5 +1,10 @@
 import { createOperationRouter } from '../../transport';
 
 import * as disconnect from './disconnect.operation';
+import * as listGrants from './listGrants.operation';
+import * as revokeGrant from './revokeGrant.operation';
 
-export const execute = createOperationRouter({ disconnect });
+export const execute = createOperationRouter(
+  { disconnect, revokeGrant },
+  { listGrants },
+);

--- a/nodes/Resend/actions/account/index.ts
+++ b/nodes/Resend/actions/account/index.ts
@@ -1,9 +1,11 @@
 import type { INodeProperties } from 'n8n-workflow';
 
 import * as disconnect from './disconnect.operation';
+import * as listGrants from './listGrants.operation';
+import * as revokeGrant from './revokeGrant.operation';
 
 export { execute } from './execute';
-export { disconnect };
+export { disconnect, listGrants, revokeGrant };
 
 export const operations: INodeProperties[] = [
   {
@@ -24,6 +26,20 @@ export const operations: INodeProperties[] = [
           'Revoke the connected Resend OAuth2 grant, ending the connection to your Resend account',
         action: 'Disconnect the resend account',
       },
+      {
+        name: 'List Grants',
+        value: 'listGrants',
+        description:
+          'Retrieve the OAuth grants issued by your team, including revoked ones',
+        action: 'List oauth grants',
+      },
+      {
+        name: 'Revoke Grant',
+        value: 'revokeGrant',
+        description:
+          'Revoke an OAuth grant by ID, immediately disconnecting that OAuth client',
+        action: 'Revoke an oauth grant',
+      },
     ],
     default: 'disconnect',
   },
@@ -32,4 +48,6 @@ export const operations: INodeProperties[] = [
 export const descriptions: INodeProperties[] = [
   ...operations,
   ...disconnect.description,
+  ...listGrants.description,
+  ...revokeGrant.description,
 ];

--- a/nodes/Resend/actions/account/listGrants.operation.ts
+++ b/nodes/Resend/actions/account/listGrants.operation.ts
@@ -1,0 +1,46 @@
+import type {
+  IExecuteFunctions,
+  INodeExecutionData,
+  INodeProperties,
+} from 'n8n-workflow';
+import { createListExecutionData, requestList } from '../../transport';
+
+export const description: INodeProperties[] = [
+  {
+    displayName: 'Return All',
+    name: 'returnAll',
+    type: 'boolean',
+    default: false,
+    displayOptions: {
+      show: {
+        resource: ['account'],
+        operation: ['listGrants'],
+      },
+    },
+    description: 'Whether to return all results or only up to a given limit',
+  },
+  {
+    displayName: 'Limit',
+    name: 'limit',
+    type: 'number',
+    default: 50,
+    typeOptions: {
+      minValue: 1,
+    },
+    displayOptions: {
+      show: {
+        resource: ['account'],
+        operation: ['listGrants'],
+        returnAll: [false],
+      },
+    },
+    description: 'Max number of results to return',
+  },
+];
+
+export async function execute(
+  this: IExecuteFunctions,
+): Promise<INodeExecutionData[]> {
+  const items = await requestList.call(this, '/oauth/grants');
+  return createListExecutionData.call(this, items);
+}

--- a/nodes/Resend/actions/account/revokeGrant.operation.ts
+++ b/nodes/Resend/actions/account/revokeGrant.operation.ts
@@ -1,0 +1,40 @@
+import type {
+  IExecuteFunctions,
+  INodeExecutionData,
+  INodeProperties,
+} from 'n8n-workflow';
+import { apiRequest } from '../../transport';
+
+export const description: INodeProperties[] = [
+  {
+    displayName: 'OAuth Grant ID',
+    name: 'oauthGrantId',
+    type: 'string',
+    required: true,
+    default: '',
+    placeholder: '650e8400-e29b-41d4-a716-446655440001',
+    displayOptions: {
+      show: {
+        resource: ['account'],
+        operation: ['revokeGrant'],
+      },
+    },
+    description:
+      'The unique identifier of the OAuth grant to revoke. Revoking a grant immediately disconnects that OAuth client and invalidates its access and refresh tokens. This cannot be undone.',
+  },
+];
+
+export async function execute(
+  this: IExecuteFunctions,
+  index: number,
+): Promise<INodeExecutionData[]> {
+  const oauthGrantId = this.getNodeParameter('oauthGrantId', index) as string;
+
+  const response = await apiRequest.call(
+    this,
+    'DELETE',
+    `/oauth/grants/${encodeURIComponent(oauthGrantId)}`,
+  );
+
+  return [{ json: response, pairedItem: { item: index } }];
+}

--- a/tests/operationRequests.test.ts
+++ b/tests/operationRequests.test.ts
@@ -41,6 +41,24 @@ const listQuery = { limit: 50 };
 
 const cases: RequestCase[] = [
   {
+    resource: 'account',
+    execute: account.execute,
+    operation: 'listGrants',
+    parameters: listParameters,
+    response: { data: [] },
+    method: 'GET',
+    endpoint: '/oauth/grants',
+    qs: listQuery,
+  },
+  {
+    resource: 'account',
+    execute: account.execute,
+    operation: 'revokeGrant',
+    parameters: { oauthGrantId: 'grant 1' },
+    method: 'DELETE',
+    endpoint: '/oauth/grants/grant%201',
+  },
+  {
     resource: 'broadcasts',
     execute: broadcasts.execute,
     operation: 'create',


### PR DESCRIPTION
Adds coverage for Resend's OAuth grant endpoints, which are published in the [OpenAPI spec](https://github.com/resend/resend-openapi/blob/main/resend.yaml) but were not implemented in this node. They live on the existing **Account** resource, alongside `Disconnect`.

## Operations

| Operation | Method | Endpoint | Docs |
| --- | --- | --- | --- |
| `listGrants` (List Grants) | `GET` | `/oauth/grants` | [List grants](https://resend.com/docs/api-reference/oauth/list-grants) |
| `revokeGrant` (Revoke Grant) | `DELETE` | `/oauth/grants/{oauth_grant_id}` | [Revoke grant](https://resend.com/docs/api-reference/oauth/revoke-grant) |

**List Grants** returns every OAuth grant issued by the authenticated team, including already-revoked ones. The endpoint is cursor paginated (`limit` / `after` / `before` with `has_more` in the response), so it uses the shared `requestList` helper and exposes the standard **Return All** / **Limit** parameters.

**Revoke Grant** takes a plain required **OAuth Grant ID** string (there is no grant option loader, matching the precedent for workflow run IDs) and returns the `oauth_grant` revocation object.

> [!WARNING]
> Revoking a grant is irreversible. It immediately disconnects that OAuth client and invalidates all of its access and refresh tokens. The parameter description states this in the node UI.

## Changes

- `nodes/Resend/actions/account/listGrants.operation.ts` (new)
- `nodes/Resend/actions/account/revokeGrant.operation.ts` (new)
- `nodes/Resend/actions/account/index.ts` — registers both operations
- `nodes/Resend/actions/account/execute.ts` — now a real `createOperationRouter` (`disconnect` + `revokeGrant` as item ops, `listGrants` as a list op)
- `nodes/Resend/Resend.node.ts` — subtitle labels plus an updated Account resource description
- `README.md` — API coverage table
- `tests/operationRequests.test.ts` — a request case per operation

## Verification

- `vitest run` — 10 files, 451 tests passed (was 449 on `main`)
- `tsc --noEmit` — clean
- `biome check` — clean, 171 files
- `eslint .` (the ruleset behind `n8n-node lint`) — exit 0, no findings