### PR TITLE
fix: run list operations once instead of once per input item

### DIFF
--- a/nodes/Resend/actions/router.ts
+++ b/nodes/Resend/actions/router.ts
@@ -4,7 +4,7 @@ import type {
   INodeExecutionData,
 } from 'n8n-workflow';
 import { NodeApiError, NodeOperationError } from 'n8n-workflow';
-import { handleResendApiError } from '../transport';
+import { handleResendApiError, type OperationRouter } from '../transport';
 import * as account from './account';
 import * as broadcasts from './broadcast';
 import * as contacts from './contact';
@@ -21,7 +21,7 @@ import * as topics from './topic';
 import * as webhooks from './webhook';
 import * as workflows from './workflow';
 
-const resourceModules: Record<string, { execute: typeof email.execute }> = {
+const resourceModules: Record<string, { execute: OperationRouter }> = {
   account,
   email,
   templates,
@@ -46,6 +46,15 @@ export async function router(
   const returnData: INodeExecutionData[] = [];
 
   for (let i = 0; i < items.length; i++) {
+    // List operations have no per-item input: they resolve their parameters at
+    // item index 0 and return a whole collection, so running them once per input
+    // item would repeat the same API calls and emit duplicate output rows.
+    // Because of that we let item 0 decide: `resource`/`operation` are evaluated
+    // for the first item, and if that resolves to a list operation we run it once
+    // and stop. Per-item expressions on `resource`/`operation` are therefore not
+    // honoured for list operations (they still are for item operations).
+    let isListOperation = false;
+
     try {
       const resource = this.getNodeParameter('resource', i) as string;
       const operation = this.getNodeParameter('operation', i) as string;
@@ -58,27 +67,33 @@ export async function router(
         );
       }
 
+      isListOperation = mod.execute.listOperations.has(operation);
+
       const executionData = await mod.execute.call(this, i, operation);
       returnData.push(...executionData);
     } catch (error) {
-      if (this.continueOnFail()) {
-        const errorData: IDataObject = {
-          error: (error as Error).message,
-        };
-
-        if (error instanceof NodeApiError) {
-          if (error.httpCode) {
-            errorData.statusCode = error.httpCode;
-          }
-          if (error.description) {
-            errorData.description = error.description;
-          }
-        }
-
-        returnData.push({ json: errorData, pairedItem: { item: i } });
-        continue;
+      if (!this.continueOnFail()) {
+        handleResendApiError(this.getNode(), error, i);
       }
-      handleResendApiError(this.getNode(), error, i);
+
+      const errorData: IDataObject = {
+        error: (error as Error).message,
+      };
+
+      if (error instanceof NodeApiError) {
+        if (error.httpCode) {
+          errorData.statusCode = error.httpCode;
+        }
+        if (error.description) {
+          errorData.description = error.description;
+        }
+      }
+
+      returnData.push({ json: errorData, pairedItem: { item: i } });
+    }
+
+    if (isListOperation) {
+      break;
     }
   }
 

--- a/nodes/Resend/transport/index.ts
+++ b/nodes/Resend/transport/index.ts
@@ -494,15 +494,19 @@ interface ListOperation {
   execute(this: IExecuteFunctions): Promise<INodeExecutionData[]>;
 }
 
-export function createOperationRouter(
-  itemOps: Record<string, ItemOperation>,
-  listOps: Record<string, ListOperation> = {},
-): (
+export type OperationRouter = ((
   this: IExecuteFunctions,
   index: number,
   operation: string,
-) => Promise<INodeExecutionData[]> {
-  return async function execute(
+) => Promise<INodeExecutionData[]>) & {
+  readonly listOperations: ReadonlySet<string>;
+};
+
+export function createOperationRouter(
+  itemOps: Record<string, ItemOperation>,
+  listOps: Record<string, ListOperation> = {},
+): OperationRouter {
+  const execute = async function (
     this: IExecuteFunctions,
     index: number,
     operation: string,
@@ -520,4 +524,8 @@ export function createOperationRouter(
       `Unsupported operation: ${operation}`,
     );
   };
+
+  return Object.assign(execute, {
+    listOperations: new Set(Object.keys(listOps)) as ReadonlySet<string>,
+  });
 }

--- a/tests/router.test.ts
+++ b/tests/router.test.ts
@@ -2,7 +2,10 @@ import { NodeApiError } from 'n8n-workflow';
 import { describe, expect, it, vi } from 'vitest';
 import * as email from '../nodes/Resend/actions/email';
 import { router } from '../nodes/Resend/actions/router';
+import * as suppressions from '../nodes/Resend/actions/suppression';
 import { createExecuteMock, testNode } from './helpers/context';
+
+const threeItems = [{ json: {} }, { json: {} }, { json: {} }];
 
 describe('router', () => {
   it('dispatches to the resource module for every input item', async () => {
@@ -26,6 +29,64 @@ describe('router', () => {
       ],
     ]);
     expect(executeSpy).toHaveBeenCalledTimes(2);
+    executeSpy.mockRestore();
+  });
+
+  it('runs a list operation once no matter how many input items there are', async () => {
+    const { context, httpRequest } = createExecuteMock({
+      parameters: {
+        resource: 'suppressions',
+        operation: 'list',
+        returnAll: false,
+        limit: 50,
+      },
+      inputData: threeItems,
+      response: { data: [{ id: 'sup_1' }, { id: 'sup_2' }], has_more: false },
+    });
+
+    const [items] = await router.call(context);
+
+    expect(httpRequest).toHaveBeenCalledTimes(1);
+    expect(items).toEqual([
+      { json: { id: 'sup_1' }, pairedItem: { item: 0 } },
+      { json: { id: 'sup_2' }, pairedItem: { item: 0 } },
+    ]);
+  });
+
+  it('still runs an item operation once per input item', async () => {
+    const { context, httpRequest } = createExecuteMock({
+      parameters: {
+        resource: 'suppressions',
+        operation: 'get',
+        suppressionIdentifier: { mode: 'id', value: 'sup_1' },
+      },
+      inputData: threeItems,
+      response: { id: 'sup_1' },
+    });
+
+    const [items] = await router.call(context);
+
+    expect(httpRequest).toHaveBeenCalledTimes(3);
+    expect(items).toHaveLength(3);
+  });
+
+  it('produces a single error item when a list operation fails with continueOnFail', async () => {
+    const executeSpy = vi
+      .spyOn(suppressions, 'execute')
+      .mockRejectedValue(new Error('list boom'));
+
+    const { context } = createExecuteMock({
+      parameters: { resource: 'suppressions', operation: 'list' },
+      inputData: threeItems,
+      continueOnFail: true,
+    });
+
+    const result = await router.call(context);
+
+    expect(executeSpy).toHaveBeenCalledTimes(1);
+    expect(result).toEqual([
+      [{ json: { error: 'list boom' }, pairedItem: { item: 0 } }],
+    ]);
     executeSpy.mockRestore();
   });
 


### PR DESCRIPTION
## The bug

`nodes/Resend/actions/router.ts` loops over every input item and calls `mod.execute.call(this, i, operation)` for each one. `createOperationRouter(itemOps, listOps)` in `nodes/Resend/transport/index.ts` splits operations into two maps precisely because list/collection endpoints have **no per-item input** — they are written as `execute(this)` with no index and resolve their parameters at index 0. But the list branch just ignored the index and re-ran the operation, so a list operation executed once per input item.

### Reproduction (measured)

With `resource: 'suppressions'`, `operation: 'list'` and **3 input items**:

| | before | after |
|---|---|---|
| API calls to `/suppressions` | **3** | **1** |
| output rows for a 1-row list | **3** (duplicates) | **1** |

### Why it matters

- **Wasted rate limit.** Resend's list endpoints are rate limited; N input items meant N identical requests.
- **Wall-clock multiplication.** `requestList` paginates and `await sleep(1000)` between pages, so a `Return All` over a multi-page collection had its entire paginated walk — sleeps included — repeated once per input item.
- **Wrong output.** The extra rows are exact duplicates of the same collection, and they all carry `pairedItem: { item: 0 }` (set by `createListExecutionData`), so downstream nodes see N copies of the same records.

## The fix

- `createOperationRouter` now returns an `OperationRouter` — the same function as before, augmented via `Object.assign` with a `listOperations: ReadonlySet<string>` naming the operations registered in the `listOps` map. `OperationRouter` is exported from `nodes/Resend/transport`.
- `router.ts` types `resourceModules` as `Record<string, { execute: OperationRouter }>` and consults `mod.execute.listOperations.has(operation)`. When the resolved operation is a list op, the item loop `break`s after that one execution.

No operation modules changed; the two-map registration in each `execute.ts` is already the source of truth.

### Design decision: per-item `resource` / `operation` expressions

`resource` and `operation` are read with `getNodeParameter(..., i)`, so in principle an expression could make them differ per item. The rule implemented here is the simple, defensible one:

> **Item 0 decides.** `resource`/`operation` are evaluated for the first input item; if that resolves to a list operation, it runs once and the loop stops. Per-item expressions on `resource`/`operation` are therefore **not** honoured for list operations. They still are for item operations, which continue to run once per item as before.

This is consistent with how list operations already behave — every other parameter they read (`returnAll`, `limit`, filters) is already resolved at index 0 inside the operation itself, so honouring a per-item `operation` switch would have been incoherent anyway. The rule is documented in a comment at the top of the loop in `router.ts`.

`continueOnFail()` is preserved: if a list operation throws with `continueOnFail` enabled, exactly **one** error item is emitted (`pairedItem: { item: 0 }`) rather than one per input item. The `catch` block was restructured (early `handleResendApiError` when not continuing, which is typed `never`) so the `break` applies to both the success and the error path. `pairedItem` handling for list results is untouched — `createListExecutionData` still pins them to item 0.

## Affected resources

All 15 resource modules go through `createOperationRouter` (verified by grep over `nodes/Resend/actions/*/execute.ts` — including `account/execute.ts`, which is a one-liner but does use it). 14 of them register at least one list operation and are therefore fixed:

`email` (`list`), `templates` (`list`), `domains` (`list`), `broadcasts` (`list`), `segments` (`list`, `listContacts`), `suppressions` (`list`), `topics` (`list`), `contacts` (`list`), `contactProperties` (`list`), `webhooks` (`list`), `receivingEmails` (`list`), `workflows` (`list`), `events` (`list`), `logs` (`list`).

`account` registers no list operations and is unaffected.

## ⚠️ Behaviour change

This changes node output. A workflow that feeds N items into a list operation previously received N duplicate copies of the collection and now receives one. Any workflow that was (probably unknowingly) relying on that duplication — e.g. using the row count downstream — will see different output.

## Tests

Three new cases in `tests/router.test.ts`:

1. A list operation with 3 input items makes exactly **1** API call and returns the collection once, with `pairedItem: { item: 0 }`.
2. An item operation (`suppressions:get`) with 3 input items still makes **3** calls and returns **3** results — guards against over-correcting.
3. A list operation that throws with `continueOnFail()` enabled produces exactly **one** error item and invokes the resource module once.

**No existing test needed modification** — none of the 449 tests on `main` were encoding the duplicating behaviour.

## Verification

| command | result |
|---|---|
| `biome check --write` | `Checked 169 files in 53ms. No fixes applied.` |
| `tsc --noEmit` | exit 0, no output |
| `vitest run` | `Test Files 10 passed (10)` / `Tests 452 passed (452)` (449 baseline + 3 new) |
| `biome check` | `Checked 169 files in 27ms. No fixes applied.` |
| `eslint .` | exit 0, no output |
| `pnpm lint:n8n` | exit 0, no findings |
